### PR TITLE
feat: User update/delete 구현 및 Swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/supersonic/limitedstore/common/config/SecurityConfig.java
+++ b/src/main/java/com/supersonic/limitedstore/common/config/SecurityConfig.java
@@ -23,7 +23,12 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
                     "/v1/users/sign-up",
-                    "/v1/users/login"
+                    "/v1/users/login",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
+                    "/swagger-resources/**",
+                    "/webjars/**"
+
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/supersonic/limitedstore/common/config/SwaggerConfig.java
+++ b/src/main/java/com/supersonic/limitedstore/common/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.supersonic.limitedstore.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+            .components(new Components().addSecuritySchemes("BearerAuth",
+                new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+            ))
+            .info(new Info()
+                .title("limited-store API")
+                .description("Monolithic Version API Docs")
+                .version("1.0.0")
+            );
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/common/dto/ApiResponse.java
+++ b/src/main/java/com/supersonic/limitedstore/common/dto/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.supersonic.limitedstore.common.dto;
 
+import com.supersonic.limitedstore.common.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,6 +23,14 @@ public class ApiResponse<T> {
         return ApiResponse.builder()
             .status(status)
             .message(message)
+            .data(null)
+            .build();
+    }
+
+    public static ApiResponse<?> error(ErrorCode errorCode) {
+        return ApiResponse.builder()
+            .status(errorCode.getHttpStatus().value())
+            .message(errorCode.getMessage())
             .data(null)
             .build();
     }

--- a/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
+++ b/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "이메일이 존재하지 않습니다."),
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "중복되는 이메일 입니다."),
     NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "중복되는 닉네임 입니다."),
+    USER_DELETED(HttpStatus.FORBIDDEN, "탈퇴된 계정입니다."),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "Product not found"),

--- a/src/main/java/com/supersonic/limitedstore/domain/user/entity/User.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/entity/User.java
@@ -1,6 +1,9 @@
 package com.supersonic.limitedstore.domain.user.entity;
 
+import com.supersonic.limitedstore.common.dto.ApiResponse;
 import com.supersonic.limitedstore.common.entity.BaseEntity;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -34,4 +37,10 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private String password;
+
+    public void updateUser(UserUpdateRequestDto dto) {
+        if (dto.getNickname() != null) {
+            this.nickname = dto.getNickname();
+        }
+    }
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/controller/UserController.java
@@ -6,6 +6,7 @@ import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.user.entity.User;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.LoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
 import com.supersonic.limitedstore.domain.user.service.UserService;
@@ -14,7 +15,9 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,10 +44,6 @@ public class UserController {
     public ApiResponse<UserResponseDto> getMyInfo(HttpServletRequest request) {
         String email = (String) request.getAttribute("email");
 
-        if (email == null) {
-            throw new CustomException(ErrorCode.NOT_FOUND_EMAIL);
-        }
-
         User user = userService.getUserByEmail(email);
 
         return ApiResponse.ok(
@@ -54,5 +53,18 @@ public class UserController {
                 .nickname(user.getNickname())
                 .build()
         );
+    }
+
+    @PatchMapping("/me")
+    public ApiResponse<UserResponseDto> updateMyInfo(@RequestBody @Valid UserUpdateRequestDto dto, HttpServletRequest request) {
+        String email = (String) request.getAttribute("email");
+        return userService.updateUser(dto, email);
+    }
+
+    @DeleteMapping("/me")
+    public ApiResponse<Void> userDelete(HttpServletRequest request) {
+        String email = (String) request.getAttribute("email");
+        userService.deleteUser(email);
+        return ApiResponse.ok(null);
     }
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserSignupRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserSignupRequestDto.java
@@ -17,11 +17,11 @@ public class UserSignupRequestDto {
 
     @NotBlank
     @Email
-    @Size(min = 10, max = 100)
+    @Size(min = 8, max = 100)
     private String email;
 
     @NotBlank
-    @Size(min = 10, max = 100)
+    @Size(min = 5, max = 100)
     private String password;
 
     @NotBlank

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserUpdateRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserUpdateRequestDto.java
@@ -1,7 +1,7 @@
 package com.supersonic.limitedstore.domain.user.presentation.dto.req;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,16 +9,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginRequestDto {
+@Builder
+public class UserUpdateRequestDto {
+
+    @NotNull
     @Email
-    @Size(min = 8, max = 100)
     private String email;
 
-    @NotBlank
-    @Size(min = 5, max = 100)
-    private String password;
+    @NotNull
+    @Size(min = 1, max = 20)
+    private String nickname;
 
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.user.entity.User;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.LoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
 import com.supersonic.limitedstore.domain.user.repository.UserRepository;
@@ -65,6 +66,10 @@ public class UserService {
         User user = userRepository.findByEmail(dto.getEmail()).orElseThrow(
             () -> new CustomException(ErrorCode.NOT_FOUND_EMAIL));
 
+        if (user.isDeleted()) {
+            throw new CustomException(ErrorCode.USER_DELETED);
+        }
+
         if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
@@ -81,9 +86,55 @@ public class UserService {
         );
     }
 
-    public User getUserByEmail(String email) {
-        return userRepository.findByEmail(email).orElseThrow(
+    public ApiResponse<UserResponseDto> updateUser (UserUpdateRequestDto dto, String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(
             () -> new CustomException(ErrorCode.NOT_FOUND_EMAIL)
         );
+
+        if (user.isDeleted()) {
+            throw new CustomException(ErrorCode.USER_DELETED);
+        }
+
+        if (userRepository.existsByNickname(dto.getNickname())
+        && !user.getNickname().equals(dto.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_DUPLICATED);
+        }
+
+        user.updateUser(dto);
+        userRepository.save(user);
+
+        return ApiResponse.ok(
+            UserResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build()
+        );
+    }
+
+    public void deleteUser(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(
+            () -> new CustomException(ErrorCode.NOT_FOUND_EMAIL));
+
+        if (user.isDeleted()) {
+            throw new CustomException(ErrorCode.USER_DELETED);
+        }
+
+        user.softDelete();
+        userRepository.save(user);
+    }
+
+
+
+    public User getUserByEmail(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(
+            () -> new CustomException(ErrorCode.NOT_FOUND_EMAIL)
+        );
+
+        if (user.isDeleted()) {
+            throw new CustomException(ErrorCode.USER_DELETED);
+        }
+
+        return user;
     }
 }

--- a/src/main/java/com/supersonic/limitedstore/security/JwtTokenProvider.java
+++ b/src/main/java/com/supersonic/limitedstore/security/JwtTokenProvider.java
@@ -62,9 +62,4 @@ public class JwtTokenProvider {
             return false;
         }
     }
-
-
-
-
-
 }


### PR DESCRIPTION
## 구현 내용

### 1) 회원 정보 수정 (PATCH /v1/users/me)
- 닉네임 수정 기능 구현
- 닉네임 중복 검증 로직 추가
- 정상 사용자에 한해 수정 가능하도록 처리

---

### 2) 회원 탈퇴 (DELETE /v1/users/me)
- 회원 탈퇴 API 구현
- soft delete 방식 적용
  - isDeleted = true 처리
  - DB에서 실제 삭제는 수행하지 않음

---

### 3) Swagger 설정 적용
- Swagger UI 적용
- JWT Bearer 인증 연동
- 인증이 필요한 API 테스트 환경 개선

---

### 4) softDelete 사용자 처리 보완
- softDelete된 사용자가 update/delete 요청을 수행할 수 있는 문제 수정
- updateUser(), deleteUser() 로직에 softDelete 검증 추가
- softDelete된 계정은 UPDATE / DELETE 요청 시 `USER_DELETED` 예외 반환하도록 처리

---

## 기술적 고려 사항
- 사용자 데이터 보존을 위해 물리 삭제 대신 soft delete 방식 채택
- softDelete 상태를 모든 사용자 변경 API의 선행 검증 조건으로 통합
- 인증이 필요한 API 테스트 편의성을 위해 Swagger에 JWT 인증 설정 추가
- 이후 관리자 기능 또는 계정 복구 기능 확장을 고려한 구조 유지

---

## 관련 이슈
- closes #3
