### PR TITLE
feat: UserServiceTest 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/controller/UserController.java
@@ -1,10 +1,8 @@
 package com.supersonic.limitedstore.domain.user.presentation.controller;
 
 import com.supersonic.limitedstore.common.dto.ApiResponse;
-import com.supersonic.limitedstore.common.exception.CustomException;
-import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.user.entity.User;
-import com.supersonic.limitedstore.domain.user.presentation.dto.req.LoginRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
@@ -13,8 +11,6 @@ import com.supersonic.limitedstore.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,7 +32,7 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ApiResponse<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto dto) {
+    public ApiResponse<LoginResponseDto> login(@RequestBody @Valid UserLoginRequestDto dto) {
         return userService.login(dto);
     }
 

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserLoginRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserLoginRequestDto.java
@@ -2,6 +2,7 @@ package com.supersonic.limitedstore.domain.user.presentation.dto.req;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,8 +13,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginRequestDto {
+public class UserLoginRequestDto {
     @Email
+    @NotBlank
     @Size(min = 8, max = 100)
     private String email;
 

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserUpdateRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package com.supersonic.limitedstore.domain.user.presentation.dto.req;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -14,11 +15,11 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UserUpdateRequestDto {
 
-    @NotNull
+    @NotBlank
     @Email
     private String email;
 
-    @NotNull
+    @NotBlank
     @Size(min = 1, max = 20)
     private String nickname;
 

--- a/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
@@ -1,20 +1,16 @@
 package com.supersonic.limitedstore.domain.user.service;
 
-import com.supersonic.limitedstore.common.config.SecurityConfig;
 import com.supersonic.limitedstore.common.dto.ApiResponse;
 import com.supersonic.limitedstore.common.exception.CustomException;
 import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.user.entity.User;
-import com.supersonic.limitedstore.domain.user.presentation.dto.req.LoginRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
 import com.supersonic.limitedstore.domain.user.repository.UserRepository;
 import com.supersonic.limitedstore.security.JwtTokenProvider;
-import java.util.UUID;
-import jdk.jshell.spi.ExecutionControl;
-import jdk.jshell.spi.ExecutionControl.UserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -62,7 +58,7 @@ public class UserService {
         );
     }
 
-    public ApiResponse<LoginResponseDto> login(LoginRequestDto dto) {
+    public ApiResponse<LoginResponseDto> login(UserLoginRequestDto dto) {
         User user = userRepository.findByEmail(dto.getEmail()).orElseThrow(
             () -> new CustomException(ErrorCode.NOT_FOUND_EMAIL));
 

--- a/src/test/java/com/supersonic/limitedstore/user/UserServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/user/UserServiceTest.java
@@ -1,0 +1,317 @@
+package com.supersonic.limitedstore.user;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
+import com.supersonic.limitedstore.domain.user.entity.User;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
+import com.supersonic.limitedstore.domain.user.repository.UserRepository;
+import com.supersonic.limitedstore.domain.user.service.UserService;
+import com.supersonic.limitedstore.security.JwtTokenProvider;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    UserService userService;
+
+    @Test
+    void 회원가입_성공() {
+        //given
+        String email = "test@test.com";
+        UserSignupRequestDto dto = UserSignupRequestDto.builder()
+                .email(email)
+                    .password("1q2w3e4r!")
+                        .nickname("슈퍼코딩")
+                            .build();
+
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(false);
+        when(passwordEncoder.encode(dto.getPassword())).thenReturn("encodedPw");
+
+        User savedUser = User.builder()
+            .id(UUID.randomUUID())
+            .email(dto.getEmail())
+            .password("encodedPw")
+            .nickname(dto.getNickname())
+            .build();
+
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        //when
+        ApiResponse<UserResponseDto> result = userService.signup(dto);
+
+        //then
+        assertEquals(200, result.getStatus());
+        assertEquals("test@test.com", result.getData().getEmail());
+        assertEquals("슈퍼코딩", result.getData().getNickname());
+
+    }
+
+    @Test
+    void 회원가입_이메일중복_실패() {
+        //given
+        String email = "test@test.com";
+        UserSignupRequestDto dto = UserSignupRequestDto.builder()
+                .email(email)
+                    .password("pw")
+                        .nickname("슈퍼코딩")
+                            .build();
+
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(true);
+
+        //when & then
+        assertThrows(CustomException.class,
+            () -> userService.signup(dto));
+    }
+
+    @Test
+    void 회원가입_닉네임중복_실패() {
+        //given
+        String email = "test@test.com";
+        UserSignupRequestDto dto = UserSignupRequestDto.builder()
+                .email(email)
+                    .nickname("슈퍼코딩")
+                        .password("1q2w3e4r!")
+                            .build();
+
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(true);
+
+        //when & then
+        assertThrows(CustomException.class,
+            () -> userService.signup(dto));
+
+    }
+
+    @Test
+    void 로그인_성공() {
+        //given
+        String email = "test@test.com";
+        UserLoginRequestDto dto = UserLoginRequestDto.builder()
+            .email(email)
+            .password("1q2w3e4r!")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("encodedPW")
+            .nickname("tester")
+            .build();
+
+        when(userRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(dto.getPassword(), user.getPassword())).thenReturn(true);
+        when(jwtTokenProvider.createToken(any())).thenReturn("token");
+
+        //when
+        ApiResponse<LoginResponseDto> result = userService.login(dto);
+
+        //then
+        assertThat(result.getStatus()).isEqualTo(200);
+        assertThat(result.getData().getEmail()).isEqualTo(email);
+        assertThat(result.getData().getAccessToken()).isEqualTo("token");
+    }
+
+    @Test
+    void 로그인_실패_비밀번호불일치() {
+        //given
+        String email = "test@test.com";
+
+        UserLoginRequestDto dto = UserLoginRequestDto.builder()
+            .email(email)
+            .password("wrongPw")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("encodedPW")
+            .nickname("tester")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(dto.getPassword(), user.getPassword())).thenReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> userService.login(dto))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+    }
+
+    @Test
+    void 로그인_실패_이메일없음() {
+        //given
+        UserLoginRequestDto dto = UserLoginRequestDto.builder()
+            .email("notfound@test.com")
+            .password("1q2w3e4r!")
+            .build();
+
+        when(userRepository.findByEmail(dto.getEmail())).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.login(dto))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NOT_FOUND_EMAIL.getMessage());
+    }
+
+    @Test
+    void 내정보조회_성공() {
+     //given
+     String email = "test@test.com";
+
+     User user = User.builder()
+         .email(email)
+         .nickname("tester")
+         .password("encodedPW")
+         .build();
+
+     when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+     //when
+        User result = userService.getUserByEmail(email);
+
+        //then
+        assertThat(result.getEmail()).isEqualTo(email);
+        assertThat(result.getNickname()).isEqualTo("tester");
+    }
+
+    @Test
+    void 내정보조회_실패_삭제된계정() {
+    //given
+    String email = "test@test.com";
+
+    User deletedUser = User.builder()
+        .email(email)
+        .nickname("tester")
+        .password("encodedPW")
+        .build();
+    deletedUser.softDelete();
+
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(deletedUser));
+
+    //when & then
+        assertThatThrownBy(() -> userService.getUserByEmail(email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.USER_DELETED.getMessage());
+    }
+
+    @Test
+    void 내정보조회_실패_이메일없음() {
+        //given
+        String email = "test@test.com";
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.getUserByEmail(email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NOT_FOUND_EMAIL.getMessage());
+    }
+
+    @Test
+    void 회원정보수정_성공() {
+        //given
+        String email = "test@test.com";
+
+        UserUpdateRequestDto dto = UserUpdateRequestDto.builder()
+            .nickname("newNick")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("pw")
+            .nickname("oldNick")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(false);
+
+        //when
+        ApiResponse<UserResponseDto> result = userService.updateUser(dto, email);
+
+        //then
+        assertThat(result.getData().getNickname()).isEqualTo(dto.getNickname());
+        verify(userRepository).save(any());
+    }
+
+    @Test
+    void 회원정보수정_실패_닉네임중복() {
+        //given
+        String email = "test@test.com";
+
+        UserUpdateRequestDto dto = UserUpdateRequestDto.builder()
+            .nickname("duplicateNick")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("pw")
+            .nickname("oldNick")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(true);
+
+        //when & then
+        assertThatThrownBy(() -> userService.updateUser(dto, email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NICKNAME_DUPLICATED.getMessage());
+    }
+
+    @Test
+    void 회원삭제_성공() {
+        String email = "test@test.com";
+
+        User user = User.builder()
+            .email(email)
+            .password("pw")
+            .nickname("tester")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        //when
+        userService.deleteUser(email);
+
+        //then
+        assertThat(user.isDeleted()).isTrue();
+        verify(userRepository).save(any());
+    }
+
+    @Test
+    void 회원삭제_실패() {
+        String email = "notfound@test.com";
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.deleteUser(email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NOT_FOUND_EMAIL.getMessage());
+
+    }
+}


### PR DESCRIPTION
## 구현 내용

### 1) 회원가입 서비스 테스트
- 정상 회원가입 성공 케이스 검증
- 이메일 중복 시 예외 발생 검증
- 닉네임 중복 시 예외 발생 검증

---

### 2) 로그인 서비스 테스트
- 비밀번호 일치 시 로그인 성공 검증
- 비밀번호 불일치 시 예외 발생 검증
- 존재하지 않는 이메일로 로그인 시 예외 발생 검증

---

### 3) 내 정보 조회 서비스 테스트
- 정상 사용자 조회 성공 검증
- softDelete된 사용자 조회 시 예외 발생 검증
- 존재하지 않는 이메일 조회 시 예외 발생 검증

---

### 4) 회원 정보 수정 서비스 테스트
- 닉네임 정상 수정 검증
- 중복 닉네임 수정 시 예외 발생 검증

---

### 5) 회원 삭제 서비스 테스트
- 회원 삭제 시 softDelete 정상 반영 검증
- 존재하지 않는 이메일 삭제 시 예외 발생 검증

---

## 기술적 고려 사항
- Repository, PasswordEncoder, JwtTokenProvider를 Mockito로 Mock 처리하여 테스트 범위를 Service 계층으로 한정
- 외부 의존성을 제거하고 비즈니스 로직 검증에 집중
- 정상 시나리오와 예외 시나리오를 모두 포함하여 서비스 로직 안정성 확보
- 예외 케이스를 통해 CustomException 및 ErrorCode 동작을 함께 검증

---

## 관련 이슈
- closes #5
