### PR TITLE
Feat/user controller test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.0'
+    id 'org.springframework.boot' version '3.5.0'    // ★ 반드시 여기 버전을 바꿔야 함
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -14,35 +14,29 @@ java {
     }
 }
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-
+    implementation 'org.springframework.boot:spring-boot-starter-web' // webmvc 대신 web로 변경 권장
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/supersonic/limitedstore/LimitedStoreApplication.java
+++ b/src/main/java/com/supersonic/limitedstore/LimitedStoreApplication.java
@@ -2,14 +2,13 @@ package com.supersonic.limitedstore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class LimitedStoreApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(LimitedStoreApplication.class, args);
     }
-
 }

--- a/src/main/java/com/supersonic/limitedstore/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/supersonic/limitedstore/common/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.supersonic.limitedstore.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/supersonic/limitedstore/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/supersonic/limitedstore/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.supersonic.limitedstore.common.exception;
 
 import com.supersonic.limitedstore.common.dto.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,6 +18,19 @@ public class GlobalExceptionHandler {
                 e.getErrorCode().getHttpStatus().value(),
                 e.getMessage()
             ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException ex) {
+
+        String message = ex.getBindingResult()
+            .getFieldErrors()
+            .get(0)
+            .getDefaultMessage();
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(400, message));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/controller/UserController.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/controller/UserController.java
@@ -1,20 +1,16 @@
 package com.supersonic.limitedstore.domain.user.presentation.controller;
 
 import com.supersonic.limitedstore.common.dto.ApiResponse;
-import com.supersonic.limitedstore.common.exception.CustomException;
-import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.user.entity.User;
-import com.supersonic.limitedstore.domain.user.presentation.dto.req.LoginRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
-import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserLoginResponseDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
 import com.supersonic.limitedstore.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,7 +32,7 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ApiResponse<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto dto) {
+    public ApiResponse<UserLoginResponseDto> login(@RequestBody @Valid UserLoginRequestDto dto) {
         return userService.login(dto);
     }
 

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserLoginRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/req/UserLoginRequestDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginRequestDto {
+public class UserLoginRequestDto {
     @Email
     @Size(min = 8, max = 100)
     private String email;

--- a/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/res/UserLoginResponseDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/presentation/dto/res/UserLoginResponseDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LoginResponseDto {
+public class UserLoginResponseDto {
 
     private UUID id;
     private String email;

--- a/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
@@ -1,20 +1,16 @@
 package com.supersonic.limitedstore.domain.user.service;
 
-import com.supersonic.limitedstore.common.config.SecurityConfig;
 import com.supersonic.limitedstore.common.dto.ApiResponse;
 import com.supersonic.limitedstore.common.exception.CustomException;
 import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.user.entity.User;
-import com.supersonic.limitedstore.domain.user.presentation.dto.req.LoginRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
-import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserLoginResponseDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
 import com.supersonic.limitedstore.domain.user.repository.UserRepository;
 import com.supersonic.limitedstore.security.JwtTokenProvider;
-import java.util.UUID;
-import jdk.jshell.spi.ExecutionControl;
-import jdk.jshell.spi.ExecutionControl.UserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -62,7 +58,7 @@ public class UserService {
         );
     }
 
-    public ApiResponse<LoginResponseDto> login(LoginRequestDto dto) {
+    public ApiResponse<UserLoginResponseDto> login(UserLoginRequestDto dto) {
         User user = userRepository.findByEmail(dto.getEmail()).orElseThrow(
             () -> new CustomException(ErrorCode.NOT_FOUND_EMAIL));
 
@@ -77,7 +73,7 @@ public class UserService {
         String token = jwtTokenProvider.createToken(user.getEmail());
 
         return ApiResponse.ok(
-            LoginResponseDto.builder()
+            UserLoginResponseDto.builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())

--- a/src/test/java/com/supersonic/limitedstore/user/controller/UserControllerTest.java
+++ b/src/test/java/com/supersonic/limitedstore/user/controller/UserControllerTest.java
@@ -2,6 +2,9 @@ package com.supersonic.limitedstore.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
+import com.supersonic.limitedstore.domain.user.entity.User;
 import com.supersonic.limitedstore.domain.user.presentation.controller.UserController;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
@@ -70,6 +73,50 @@ class UserControllerTest {
     }
 
     @Test
+    void 회원가입_실패_이메일형식오류() throws Exception{
+        UserSignupRequestDto requestDto = UserSignupRequestDto.builder()
+            .email("wrongEmail")
+            .password("1q2w3e4r!")
+            .nickname("tester")
+            .build();
+
+        mockMvc.perform(post("/v1/users/sign-up")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 회원가입_실패_이메일없음() throws Exception{
+        String json = """
+            {
+            "password": "1q2w3e4r!",
+            "nickname": "tester"
+            }
+            """;
+
+        mockMvc.perform(post("/v1/users/sign-up")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 회원가입_실패_닉네임없음() throws Exception {
+        String json = """
+        {
+            "email": "test@test.com",
+            "password": "1q2w3e4r!"
+        }
+    """;
+
+        mockMvc.perform(post("/v1/users/sign-up")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void 로그인_성공() throws Exception{
         UserLoginRequestDto request = UserLoginRequestDto.builder()
             .email("test@test.com")
@@ -96,7 +143,64 @@ class UserControllerTest {
     }
 
     @Test
-    void 업데이트_성공()  throws Exception{
+    void 로그인_실패_이메일형식오류() throws Exception{
+        UserLoginRequestDto requestDto = UserLoginRequestDto.builder()
+            .email("wrongEmail")
+            .password("1q2w3e4r!")
+            .build();
+
+       mockMvc.perform(post("/v1/users/login")
+           .contentType(MediaType.APPLICATION_JSON)
+           .content(objectMapper.writeValueAsString(requestDto)))
+           .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 로그인_실패_이메일없음() throws Exception{
+        UserLoginRequestDto requestDto = UserLoginRequestDto.builder()
+            .email("notfound@test.com")
+            .password("1q2w3e4r!")
+            .build();
+
+        when(userService.login(any())).thenThrow(new CustomException(ErrorCode.NOT_FOUND_EMAIL));
+
+        mockMvc.perform(post("/v1/users/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 내정보조회_성공() throws Exception{
+        String email = "test@test.com";
+
+        User user = User.builder()
+            .id(UUID.randomUUID())
+            .email(email)
+            .nickname("tester")
+            .password("encodedPW")
+            .build();
+
+        when(userService.getUserByEmail(email)).thenReturn(user);
+
+        mockMvc.perform(get("/v1/users/me")
+            .requestAttr("email", email))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.email").value(email))
+            .andExpect(jsonPath("$.data.nickname").value("tester"));
+    }
+
+
+    @Test
+    void 내정보조회_실패_이메일없음() throws Exception{
+        when(userService.getUserByEmail(any())).thenThrow(new CustomException(ErrorCode.NOT_FOUND_EMAIL));
+
+        mockMvc.perform(get("/v1/users/me"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 내정보수정_성공()  throws Exception{
         UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
             .email("test@test.com")
             .nickname("updateTester")
@@ -119,6 +223,69 @@ class UserControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.email").value("test@test.com"))
             .andExpect(jsonPath("$.data.nickname").value("updateTester"));
+    }
+
+    @Test
+    void 내정보수정_실패_닉네임없음() throws Exception{
+        String json = """
+            {
+            "email": "test@test.com"
+            }
+            """;
+
+        mockMvc.perform(patch("/v1/users/me")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 내정보수정_실패_닉네임중복() throws Exception{
+        UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
+            .email("test@test.com")
+            .nickname("dupNick")
+            .build();
+
+        when(userService.updateUser(any(), any())).thenThrow(new CustomException(ErrorCode.NICKNAME_DUPLICATED));
+
+        mockMvc.perform(patch("/v1/users/me")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isConflict());
+    }
+
+
+
+
+    @Test
+    void 회원삭제_성공()  throws Exception{
+        String email = "test@test.com";
+
+        mockMvc.perform(delete("/v1/users/me")
+            .requestAttr("email", email))
+            .andExpect(status().isOk());
+
+        verify(userService).deleteUser(email);
+    }
+
+    @Test
+    void 회원삭제_실패_이메일없음()  throws Exception{
+        doThrow(new CustomException(ErrorCode.NOT_FOUND_EMAIL))
+            .when(userService)
+            .deleteUser(null);
+
+        mockMvc.perform(delete("/v1/users/me"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 회원삭제_실패_삭제된유저()  throws Exception{
+        doThrow(new CustomException(ErrorCode.USER_DELETED))
+            .when(userService)
+            .deleteUser(any());
+
+        mockMvc.perform(delete("/v1/users/me"))
+            .andExpect(status().isForbidden());
     }
 
 

--- a/src/test/java/com/supersonic/limitedstore/user/controller/UserControllerTest.java
+++ b/src/test/java/com/supersonic/limitedstore/user/controller/UserControllerTest.java
@@ -1,0 +1,125 @@
+package com.supersonic.limitedstore.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.domain.user.presentation.controller.UserController;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserLoginResponseDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
+import com.supersonic.limitedstore.domain.user.service.UserService;
+import com.supersonic.limitedstore.security.JwtTokenProvider;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @Test
+    void 회원가입_성공() throws Exception{
+        //given
+        UserSignupRequestDto request = UserSignupRequestDto.builder()
+            .email("test@test.com")
+            .password("1q2w3e4r!")
+            .nickname("tester")
+            .build();
+
+        ApiResponse<UserResponseDto> response = ApiResponse.ok(
+            new UserResponseDto(UUID.randomUUID(), "test@test.com", "tester")
+        );
+
+        when(userService.signup(any())).thenReturn(response);
+
+        //when & then
+        mockMvc.perform(post("/v1/users/sign-up")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.email").value("test@test.com"))
+            .andExpect(jsonPath("$.data.nickname").value("tester"));
+
+    }
+
+    @Test
+    void 로그인_성공() throws Exception{
+        UserLoginRequestDto request = UserLoginRequestDto.builder()
+            .email("test@test.com")
+            .password("1q2w3e4r!")
+            .build();
+
+        ApiResponse<UserLoginResponseDto> response = ApiResponse.ok(
+            UserLoginResponseDto.builder()
+                .id(UUID.randomUUID())
+                .email("test@test.com")
+                .nickname("tester")
+                .accessToken("jwt-token")
+                .build()
+        );
+
+        when(userService.login(any())).thenReturn(response);
+
+        mockMvc.perform(post("/v1/users/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.email").value("test@test.com"))
+            .andExpect(jsonPath("$.data.accessToken").value("jwt-token"));
+    }
+
+    @Test
+    void 업데이트_성공()  throws Exception{
+        UserUpdateRequestDto requestDto = UserUpdateRequestDto.builder()
+            .email("test@test.com")
+            .nickname("updateTester")
+            .build();
+
+        ApiResponse<UserResponseDto> response = ApiResponse.ok(
+            UserResponseDto.builder()
+                .id(UUID.randomUUID())
+                .email("test@test.com")
+                .nickname("updateTester")
+                .build()
+        );
+
+        when(userService.updateUser(any(), any())).thenReturn(response);
+
+        mockMvc.perform(patch("/v1/users/me")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto))
+            .requestAttr("email", "test@test.com"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.email").value("test@test.com"))
+            .andExpect(jsonPath("$.data.nickname").value("updateTester"));
+    }
+
+
+}

--- a/src/test/java/com/supersonic/limitedstore/user/service/UserServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/user/service/UserServiceTest.java
@@ -1,0 +1,317 @@
+package com.supersonic.limitedstore.user.service;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
+import com.supersonic.limitedstore.domain.user.entity.User;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserLoginResponseDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
+import com.supersonic.limitedstore.domain.user.repository.UserRepository;
+import com.supersonic.limitedstore.domain.user.service.UserService;
+import com.supersonic.limitedstore.security.JwtTokenProvider;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    UserService userService;
+
+    @Test
+    void 회원가입_성공() {
+        //given
+        String email = "test@test.com";
+        UserSignupRequestDto dto = UserSignupRequestDto.builder()
+                .email(email)
+                    .password("1q2w3e4r!")
+                        .nickname("슈퍼코딩")
+                            .build();
+
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(false);
+        when(passwordEncoder.encode(dto.getPassword())).thenReturn("encodedPw");
+
+        User savedUser = User.builder()
+            .id(UUID.randomUUID())
+            .email(dto.getEmail())
+            .password("encodedPw")
+            .nickname(dto.getNickname())
+            .build();
+
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        //when
+        ApiResponse<UserResponseDto> result = userService.signup(dto);
+
+        //then
+        assertEquals(200, result.getStatus());
+        assertEquals("test@test.com", result.getData().getEmail());
+        assertEquals("슈퍼코딩", result.getData().getNickname());
+
+    }
+
+    @Test
+    void 회원가입_이메일중복_실패() {
+        //given
+        String email = "test@test.com";
+        UserSignupRequestDto dto = UserSignupRequestDto.builder()
+                .email(email)
+                    .password("pw")
+                        .nickname("슈퍼코딩")
+                            .build();
+
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(true);
+
+        //when & then
+        assertThrows(CustomException.class,
+            () -> userService.signup(dto));
+    }
+
+    @Test
+    void 회원가입_닉네임중복_실패() {
+        //given
+        String email = "test@test.com";
+        UserSignupRequestDto dto = UserSignupRequestDto.builder()
+                .email(email)
+                    .nickname("슈퍼코딩")
+                        .password("1q2w3e4r!")
+                            .build();
+
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(true);
+
+        //when & then
+        assertThrows(CustomException.class,
+            () -> userService.signup(dto));
+
+    }
+
+    @Test
+    void 로그인_성공() {
+        //given
+        String email = "test@test.com";
+        UserLoginRequestDto dto = UserLoginRequestDto.builder()
+            .email(email)
+            .password("1q2w3e4r!")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("encodedPW")
+            .nickname("tester")
+            .build();
+
+        when(userRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(dto.getPassword(), user.getPassword())).thenReturn(true);
+        when(jwtTokenProvider.createToken(any())).thenReturn("token");
+
+        //when
+        ApiResponse<UserLoginResponseDto> result = userService.login(dto);
+
+        //then
+        assertThat(result.getStatus()).isEqualTo(200);
+        assertThat(result.getData().getEmail()).isEqualTo(email);
+        assertThat(result.getData().getAccessToken()).isEqualTo("token");
+    }
+
+    @Test
+    void 로그인_실패_비밀번호불일치() {
+        //given
+        String email = "test@test.com";
+
+        UserLoginRequestDto dto = UserLoginRequestDto.builder()
+            .email(email)
+            .password("wrongPw")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("encodedPW")
+            .nickname("tester")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(dto.getPassword(), user.getPassword())).thenReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> userService.login(dto))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.INVALID_PASSWORD.getMessage());
+    }
+
+    @Test
+    void 로그인_실패_이메일없음() {
+        //given
+        UserLoginRequestDto dto = UserLoginRequestDto.builder()
+            .email("notfound@test.com")
+            .password("1q2w3e4r!")
+            .build();
+
+        when(userRepository.findByEmail(dto.getEmail())).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.login(dto))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NOT_FOUND_EMAIL.getMessage());
+    }
+
+    @Test
+    void 내정보조회_성공() {
+     //given
+     String email = "test@test.com";
+
+     User user = User.builder()
+         .email(email)
+         .nickname("tester")
+         .password("encodedPW")
+         .build();
+
+     when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+     //when
+        User result = userService.getUserByEmail(email);
+
+        //then
+        assertThat(result.getEmail()).isEqualTo(email);
+        assertThat(result.getNickname()).isEqualTo("tester");
+    }
+
+    @Test
+    void 내정보조회_실패_삭제된계정() {
+    //given
+    String email = "test@test.com";
+
+    User deletedUser = User.builder()
+        .email(email)
+        .nickname("tester")
+        .password("encodedPW")
+        .build();
+    deletedUser.softDelete();
+
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(deletedUser));
+
+    //when & then
+        assertThatThrownBy(() -> userService.getUserByEmail(email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.USER_DELETED.getMessage());
+    }
+
+    @Test
+    void 내정보조회_실패_이메일없음() {
+        //given
+        String email = "test@test.com";
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.getUserByEmail(email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NOT_FOUND_EMAIL.getMessage());
+    }
+
+    @Test
+    void 회원정보수정_성공() {
+        //given
+        String email = "test@test.com";
+
+        UserUpdateRequestDto dto = UserUpdateRequestDto.builder()
+            .nickname("newNick")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("pw")
+            .nickname("oldNick")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(false);
+
+        //when
+        ApiResponse<UserResponseDto> result = userService.updateUser(dto, email);
+
+        //then
+        assertThat(result.getData().getNickname()).isEqualTo(dto.getNickname());
+        verify(userRepository).save(any());
+    }
+
+    @Test
+    void 회원정보수정_실패_닉네임중복() {
+        //given
+        String email = "test@test.com";
+
+        UserUpdateRequestDto dto = UserUpdateRequestDto.builder()
+            .nickname("duplicateNick")
+            .build();
+
+        User user = User.builder()
+            .email(email)
+            .password("pw")
+            .nickname("oldNick")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(dto.getNickname())).thenReturn(true);
+
+        //when & then
+        assertThatThrownBy(() -> userService.updateUser(dto, email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NICKNAME_DUPLICATED.getMessage());
+    }
+
+    @Test
+    void 회원삭제_성공() {
+        String email = "test@test.com";
+
+        User user = User.builder()
+            .email(email)
+            .password("pw")
+            .nickname("tester")
+            .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        //when
+        userService.deleteUser(email);
+
+        //then
+        assertThat(user.isDeleted()).isTrue();
+        verify(userRepository).save(any());
+    }
+
+    @Test
+    void 회원삭제_실패() {
+        String email = "notfound@test.com";
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.deleteUser(email))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NOT_FOUND_EMAIL.getMessage());
+
+    }
+}


### PR DESCRIPTION
## 작업 내용
- UserController의 주요 기능에 대한 단위 테스트 추가
  - 회원가입 테스트 (성공 / 이메일 형식 오류)
  - 로그인 테스트 (성공 / 이메일 없음 / 비밀번호 불일치)
  - 내 정보 조회 테스트 (성공 / 삭제된 계정 / 이메일 없음)
  - 회원 정보 수정 테스트 (성공 / 닉네임 중복)
  - 회원 삭제 테스트 (성공 / 존재하지 않는 계정)

- MockMvc + @WebMvcTest 기반으로 Controller 계층 테스트 구성
- Service 의존성은 @MockBean 으로 대체하여 Controller 레이어만 검증하도록 설정
- GlobalExceptionHandler와 @Valid 검증 흐름이 정상적으로 동작하는지 함께 확인

## 테스트 결과
- 총 N개의 테스트 케이스 모두 통과
- 4xx/5xx 예외 처리 흐름 검증 완료
- DTO 검증(@Valid) 실패 시 400 BAD_REQUEST 정상 동작 확인

## 관련 이슈
- closes #7