### PR TITLE
feat: Product entity, dto, repository 구현 완료

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
@@ -1,0 +1,44 @@
+package com.supersonic.limitedstore.domain.product.entity;
+
+import com.supersonic.limitedstore.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "product")
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column()
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String description;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private Integer stock;
+
+    @Column()
+    private LocalDateTime releaseAt;
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/product/presentation/dto/req/ProductRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/presentation/dto/req/ProductRequestDto.java
@@ -1,0 +1,35 @@
+package com.supersonic.limitedstore.domain.product.presentation.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductRequestDto {
+
+    @NotBlank
+    @Size(max = 50)
+    private String name;
+
+    @Size(max = 100)
+    private String description;
+
+    @NotNull
+    @PositiveOrZero
+    private Integer price;
+
+    @NotNull
+    @PositiveOrZero
+    private Integer stock;
+
+    @NotNull
+    private String releaseAt;
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/product/presentation/dto/req/ProductUpdateRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/presentation/dto/req/ProductUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.supersonic.limitedstore.domain.product.presentation.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductUpdateRequestDto {
+    private String name;
+    private String description;
+    private Integer price;
+    private Integer stock;
+    private String releaseAt;
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/product/presentation/dto/res/ProductResponseDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/presentation/dto/res/ProductResponseDto.java
@@ -1,0 +1,40 @@
+package com.supersonic.limitedstore.domain.product.presentation.dto.res;
+
+import com.supersonic.limitedstore.common.entity.BaseEntity;
+import com.supersonic.limitedstore.domain.product.entity.Product;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductResponseDto {
+
+    private UUID id;
+    private String name;
+    private String description;
+    private Integer price;
+    private Integer stock;
+    private LocalDateTime releaseAt;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ProductResponseDto from(Product product) {
+        return ProductResponseDto.builder()
+            .id(product.getId())
+            .name(product.getName())
+            .description(product.getDescription())
+            .price(product.getPrice())
+            .stock(product.getStock())
+            .createdAt(product.getCreatedAt())
+            .updatedAt(product.getUpdatedAt())
+            .releaseAt(product.getReleaseAt())
+            .build();
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/repository/ProductRepository.java
@@ -1,0 +1,12 @@
+package com.supersonic.limitedstore.domain.product.repository;
+
+import com.supersonic.limitedstore.domain.product.entity.Product;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, UUID> {
+    List<Product> findByNameContaining(String keyword);
+
+    List<Product> findByIsDeletedFalse();
+}


### PR DESCRIPTION
## 구현 내용

### 1) Product 도메인(Entity) 추가
- Product 엔티티 생성
- id(UUID), name, description, price, stock, releaseAt(LocalDateTime) 필드 정의
- BaseEntity 상속
  - createdAt, updatedAt, deletedAt, isDeleted 포함
- soft delete 구조를 고려한 엔티티 설계

---

### 2) DTO 구성

#### ProductRequestDto (상품 생성용)
- name / description / price / stock / releaseAt 입력 필드 정의
- `@NotBlank`, `@NotNull`, `@PositiveOrZero` 등 유효성 검증 적용
- releaseAt은 String으로 받아 Service 계층에서 LocalDateTime으로 변환

#### ProductUpdateDto (상품 수정용)
- PATCH 요청을 고려하여 모든 필드를 optional로 구성
- 부분 업데이트 가능하도록 설계
- releaseAt 역시 String으로 받아 선택적 수정 가능

#### ProductResponseDto (상품 조회용)
- Entity → Response 변환을 위한 정적 팩토리 메서드 `from()` 제공
- releaseAt은 LocalDateTime 타입으로 반환

---

### 3) ProductRepository 추가
- JpaRepository 기반 기본 CRUD 기능 제공
- 추가 조회 메서드 구현
  - `findByNameContaining(String keyword)` : 상품명 키워드 검색
  - `findByIsDeletedFalse()` : soft delete가 적용된 상품만 조회

---

## 기술적 고려 사항
- soft delete 정책을 엔티티 및 조회 쿼리에 반영하여 데이터 보존 및 확장성 확보
- 날짜/시간 파싱 책임을 Service 계층으로 위임하여 Controller와 DTO 역할 분리
- PATCH 요청에 적합하도록 Update DTO를 optional 필드 구조로 설계
- 이후 Service / Controller 계층에서 비즈니스 로직 및 API 확장을 고려한 기반 구조 마련

---

## 관련 이슈
- closes #9
