### PR TITLE
feat: Product service, controller 구현

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
+++ b/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
@@ -6,22 +6,25 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Invalid request"),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized"),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "Forbidden"),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not found"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 자원을 찾을 수 없습니다."),
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "이메일이 존재하지 않습니다."),
-    EMAIL_DUPLICATED(HttpStatus.CONFLICT, "중복되는 이메일 입니다."),
-    NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "중복되는 닉네임 입니다."),
+    EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임 입니다."),
     USER_DELETED(HttpStatus.FORBIDDEN, "탈퇴된 계정입니다."),
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
-    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "Product not found"),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "Order not found"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
 
-    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "Stock is empty"),
-    DUPLICATE_ORDER(HttpStatus.BAD_REQUEST, "Order already exists"),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 패스워드 입니다." ),;
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+    PRODUCT_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 상품명입니다."),
+    DUPLICATE_ORDER(HttpStatus.BAD_REQUEST, "이미 주문한 상품입니다."),
+
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다." ),;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
@@ -27,7 +27,7 @@ public class Product extends BaseEntity {
     @Column()
     private UUID id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @Column
@@ -41,4 +41,12 @@ public class Product extends BaseEntity {
 
     @Column()
     private LocalDateTime releaseAt;
+
+    public void update(String name, String description, Integer price, Integer stock, LocalDateTime releaseAt) {
+        if (name != null) this.name = name;
+        if (description != null) this.description = description;
+        if (price != null) this.price = price;
+        if (stock != null) this.stock = stock;
+        if (releaseAt != null) this.releaseAt = releaseAt;
+    }
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/presentation/controller/ProductController.java
@@ -1,0 +1,58 @@
+package com.supersonic.limitedstore.domain.product.presentation.controller;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.domain.product.presentation.dto.req.ProductRequestDto;
+import com.supersonic.limitedstore.domain.product.presentation.dto.req.ProductUpdateRequestDto;
+import com.supersonic.limitedstore.domain.product.presentation.dto.res.ProductResponseDto;
+import com.supersonic.limitedstore.domain.product.service.ProductService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/v1/products")
+@RestController
+@AllArgsConstructor
+public class ProductController {
+
+    private ProductService productService;
+
+    @PostMapping
+    @Operation(summary = "상품 생성", description = "신규 상품을 등록합니다.")
+    public ApiResponse<ProductResponseDto> createProduct(@RequestBody @Valid ProductRequestDto dto) {
+        return productService.createProduct(dto);
+    }
+
+    @GetMapping
+    @Operation(summary = "상품 리스트 조회", description = "상품 리스트를 조회합니다.")
+    public ApiResponse<List<ProductResponseDto>> getAllProducts() {
+        return productService.getAllProducts();
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "상품 조회", description = "상품을 조회합니다.")
+    public ApiResponse<ProductResponseDto> getProductById(@PathVariable("id") UUID id) {
+        return productService.getProductById(id);
+    }
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "상품 수정", description = "상품을 수정합니다.")
+    public ApiResponse<ProductResponseDto> updateProduct(@PathVariable("id") UUID id, @RequestBody @Valid ProductUpdateRequestDto dto) {
+        return productService.updateProduct(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "상품 삭제", description = "상품을 삭제합니다.")
+    public void deleteProduct(@PathVariable("id") UUID id) {
+        productService.deleteProduct(id);
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/repository/ProductRepository.java
@@ -2,11 +2,18 @@ package com.supersonic.limitedstore.domain.product.repository;
 
 import com.supersonic.limitedstore.domain.product.entity.Product;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, UUID> {
+    boolean existsByName(String name);
+
+    Optional<Product> findByIdAndIsDeletedFalse(UUID id);
+
     List<Product> findByNameContaining(String keyword);
 
     List<Product> findByIsDeletedFalse();
+
+    List<Product> findByNameContainingAndIsDeletedFalse(String keyword);
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/product/service/ProductService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/service/ProductService.java
@@ -1,0 +1,114 @@
+package com.supersonic.limitedstore.domain.product.service;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
+import com.supersonic.limitedstore.domain.product.entity.Product;
+import com.supersonic.limitedstore.domain.product.presentation.dto.req.ProductRequestDto;
+import com.supersonic.limitedstore.domain.product.presentation.dto.req.ProductUpdateRequestDto;
+import com.supersonic.limitedstore.domain.product.presentation.dto.res.ProductResponseDto;
+import com.supersonic.limitedstore.domain.product.repository.ProductRepository;
+import com.supersonic.limitedstore.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    private static final DateTimeFormatter RELEASE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public ApiResponse<ProductResponseDto> createProduct(ProductRequestDto dto) {
+
+        if (productRepository.existsByName(dto.getName())) {
+            throw new CustomException(ErrorCode.PRODUCT_DUPLICATED);
+        }
+
+        LocalDateTime releaseAt;
+        try {
+            releaseAt = LocalDateTime.parse(dto.getReleaseAt(), RELEASE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.INVALID_DATE_FORMAT);
+        }
+
+
+
+        Product product = Product.builder()
+            .name(dto.getName())
+            .description(dto.getDescription())
+            .price(dto.getPrice())
+            .stock(dto.getStock())
+            .releaseAt(releaseAt)
+            .build();
+
+        Product saved = productRepository.save(product);
+
+        return ApiResponse.ok(
+            ProductResponseDto.from(saved)
+        );
+    }
+
+    public ApiResponse<List<ProductResponseDto>> getAllProducts() {
+        List<Product> products = productRepository.findByIsDeletedFalse();
+
+        List<ProductResponseDto> responseDtoList = products.stream()
+            .map(ProductResponseDto::from)
+            .collect(Collectors.toList());
+
+        return ApiResponse.ok(responseDtoList);
+    }
+
+    public ApiResponse<ProductResponseDto> getProductById(UUID productId) {
+        Product product = productRepository.findByIdAndIsDeletedFalse(productId).orElseThrow(
+            () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
+        );
+
+        return ApiResponse.ok(ProductResponseDto.from(product));
+    }
+
+    public ApiResponse<ProductResponseDto> updateProduct(UUID productId, ProductUpdateRequestDto dto) {
+        Product product = productRepository.findByIdAndIsDeletedFalse(productId).orElseThrow(
+            () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        LocalDateTime releaseAt = null;
+        if (dto.getReleaseAt() != null) {
+            try {
+                releaseAt = LocalDateTime.parse(dto.getReleaseAt(), RELEASE_FORMATTER);
+            } catch (DateTimeParseException e) {
+                throw new CustomException(ErrorCode.INVALID_DATE_FORMAT);
+            }
+        }
+
+            product.update(
+                dto.getName(),
+                dto.getDescription(),
+                dto.getPrice(),
+                dto.getStock(),
+                releaseAt
+            );
+
+        productRepository.save(product);
+
+        return ApiResponse.ok(ProductResponseDto.from(product));
+    }
+
+    public void deleteProduct(UUID productId) {
+        Product product = productRepository.findByIdAndIsDeletedFalse(productId).orElseThrow(
+            () -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND)
+        );
+
+        product.softDelete();
+        productRepository.save(product);
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

### 1) ProductService 구현
- 상품 생성(Create)
  - releaseAt(String) → LocalDateTime 파싱 처리
  - 잘못된 날짜 포맷 입력 시 `INVALID_DATE_FORMAT` 예외 발생
  - 상품명 중복 검사 로직 추가 (`PRODUCT_DUPLICATED`)
- 상품 전체 조회(Read-All)
  - soft delete 되지 않은 상품만 조회 (`findByIsDeletedFalse`)
- 상품 단일 조회(Read-One)
  - `findByIdAndIsDeletedFalse`를 사용하여 soft delete 상품 조회 방지
- 상품 수정(Update)
  - Product Entity의 `update()` 메서드를 활용한 부분 업데이트
  - releaseAt 파싱 및 null-safe 처리
- 상품 삭제(Delete)
  - soft delete 방식 적용 (`softDelete()`)

---

### 2) ProductController 구현
- `/v1/products` REST API 구성
- Swagger 문서화 적용
  - `@Operation(summary, description)` 사용

#### 제공 API
- POST   `/v1/products`
- GET    `/v1/products`
- GET    `/v1/products/{id}`
- PATCH  `/v1/products/{id}`
- DELETE `/v1/products/{id}`

---

## 기술적 고려 사항
- soft delete 정책을 Service 및 Repository 조회 로직 전반에 일관되게 적용
- 날짜 포맷 파싱 책임을 Service 계층으로 위임하여 Controller 역할 최소화
- 부분 수정(Update) 시 Entity 내부 메서드를 활용해 도메인 책임 명확화
- 조회/수정/삭제 시 soft delete 데이터 접근을 차단하여 데이터 무결성 확보
- Swagger 문서화를 통해 API 명세 가독성 및 테스트 편의성 개선

---

## 관련 이슈
- closes #11
