### PR TITLE
feat: ProductServiceTest 구현

### DIFF
--- a/src/test/java/com/supersonic/limitedstore/product/ProductServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/product/ProductServiceTest.java
@@ -1,0 +1,224 @@
+package com.supersonic.limitedstore.product;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
+import com.supersonic.limitedstore.domain.product.entity.Product;
+import com.supersonic.limitedstore.domain.product.presentation.dto.req.ProductRequestDto;
+import com.supersonic.limitedstore.domain.product.presentation.dto.req.ProductUpdateRequestDto;
+import com.supersonic.limitedstore.domain.product.presentation.dto.res.ProductResponseDto;
+import com.supersonic.limitedstore.domain.product.repository.ProductRepository;
+import com.supersonic.limitedstore.domain.product.service.ProductService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@ExtendWith(MockitoExtension.class)
+public class ProductServiceTest {
+
+    @InjectMocks
+    private ProductService productService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @Test
+    void 상품_생성_성공() {
+        // given
+        ProductRequestDto dto = ProductRequestDto.builder()
+            .name("테스트 상품")
+            .description("설명")
+            .price(10000)
+            .stock(10)
+            .releaseAt("2025-12-05 12:03:02")
+            .build();
+
+        LocalDateTime parsedReleaseAt = LocalDateTime.parse(dto.getReleaseAt(), formatter);
+
+        when(productRepository.existsByName(dto.getName())).thenReturn(false);
+
+        Product product = Product.builder()
+            .id(UUID.randomUUID())
+            .name(dto.getName())
+            .description(dto.getDescription())
+            .price(dto.getPrice())
+            .stock(dto.getStock())
+            .releaseAt(parsedReleaseAt)
+            .build();
+
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+
+        // when
+        ApiResponse<ProductResponseDto> result = productService.createProduct(dto);
+
+        // then
+        assertThat(result.getData().getName()).isEqualTo(dto.getName());
+        verify(productRepository, times(1)).save(any());
+    }
+
+    @Test
+    void 상품_생성_중복상품명_에러() {
+        // given
+        ProductRequestDto dto = ProductRequestDto.builder()
+            .name("중복상품")
+            .price(1000)
+            .stock(5)
+            .releaseAt("2025-12-05 12:00:00")
+            .build();
+
+        when(productRepository.existsByName(dto.getName())).thenReturn(true);
+
+        // when & then
+        assertThrows(CustomException.class, () -> productService.createProduct(dto));
+    }
+
+    @Test
+    void 상품_생성_날짜형식오류() {
+        // given
+        ProductRequestDto dto = ProductRequestDto.builder()
+            .name("상품")
+            .price(1000)
+            .stock(5)
+            .releaseAt("잘못된형식")
+            .build();
+
+        // when & then
+        assertThrows(CustomException.class, () -> productService.createProduct(dto));
+    }
+
+    // ---------------------------
+    // 상품 단일 조회 테스트
+    // ---------------------------
+
+    @Test
+    void 상품_조회_성공() {
+        // given
+        UUID id = UUID.randomUUID();
+
+        Product product = Product.builder()
+            .id(id)
+            .name("테스트")
+            .price(1000)
+            .stock(5)
+            .build();
+
+        when(productRepository.findByIdAndIsDeletedFalse(id))
+            .thenReturn(Optional.of(product));
+
+        // when
+        ApiResponse<ProductResponseDto> result = productService.getProductById(id);
+
+        // then
+        assertThat(result.getData().getId()).isEqualTo(id);
+    }
+
+    @Test
+    void 상품_조회_실패_삭제되었거나없음() {
+        // given
+        UUID id = UUID.randomUUID();
+
+        when(productRepository.findByIdAndIsDeletedFalse(id))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(CustomException.class, () -> productService.getProductById(id));
+    }
+
+    // ---------------------------
+    // 상품 전체 조회 테스트
+    // ---------------------------
+
+    @Test
+    void 상품_전체조회_성공() {
+        // given
+        List<Product> list = List.of(
+            Product.builder().id(UUID.randomUUID()).name("A").price(1000).stock(1).build(),
+            Product.builder().id(UUID.randomUUID()).name("B").price(2000).stock(2).build()
+        );
+
+        when(productRepository.findByIsDeletedFalse())
+            .thenReturn(list);
+
+        // when
+        ApiResponse<List<ProductResponseDto>> result = productService.getAllProducts();
+
+        // then
+        assertThat(result.getData().size()).isEqualTo(2);
+    }
+
+    // ---------------------------
+    // 상품 수정 테스트
+    // ---------------------------
+
+    @Test
+    void 상품_업데이트_성공() {
+        // given
+        UUID id = UUID.randomUUID();
+
+        Product product = Product.builder()
+            .id(id)
+            .name("old")
+            .price(1000)
+            .stock(10)
+            .build();
+
+        ProductUpdateRequestDto dto = ProductUpdateRequestDto.builder()
+            .name("newName")
+            .price(2000)
+            .build();
+
+        when(productRepository.findByIdAndIsDeletedFalse(id))
+            .thenReturn(Optional.of(product));
+
+        when(productRepository.save(any())).thenReturn(product);
+
+        // when
+        ApiResponse<ProductResponseDto> result = productService.updateProduct(id, dto);
+
+        // then
+        assertThat(result.getData().getName()).isEqualTo("newName");
+        assertThat(result.getData().getPrice()).isEqualTo(2000);
+        verify(productRepository, times(1)).save(any());
+    }
+
+    // ---------------------------
+    // 상품 삭제 테스트
+    // ---------------------------
+
+    @Test
+    void 상품_삭제_성공() {
+        // given
+        UUID id = UUID.randomUUID();
+
+        Product product = Product.builder()
+            .id(id)
+            .name("삭제대상")
+            .price(500)
+            .stock(1)
+            .build();
+
+        when(productRepository.findByIdAndIsDeletedFalse(id))
+            .thenReturn(Optional.of(product));
+
+        // when
+        productService.deleteProduct(id);
+
+        // then
+        assertThat(product.isDeleted()).isTrue();
+        verify(productRepository, times(1)).save(any());
+    }
+}

--- a/src/test/java/com/supersonic/limitedstore/user/UserServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/user/UserServiceTest.java
@@ -7,7 +7,7 @@ import com.supersonic.limitedstore.domain.user.entity.User;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserLoginRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserSignupRequestDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.req.UserUpdateRequestDto;
-import com.supersonic.limitedstore.domain.user.presentation.dto.res.LoginResponseDto;
+import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserLoginResponseDto;
 import com.supersonic.limitedstore.domain.user.presentation.dto.res.UserResponseDto;
 import com.supersonic.limitedstore.domain.user.repository.UserRepository;
 import com.supersonic.limitedstore.domain.user.service.UserService;
@@ -129,7 +129,7 @@ public class UserServiceTest {
         when(jwtTokenProvider.createToken(any())).thenReturn("token");
 
         //when
-        ApiResponse<LoginResponseDto> result = userService.login(dto);
+        ApiResponse<UserLoginResponseDto> result = userService.login(dto);
 
         //then
         assertThat(result.getStatus()).isEqualTo(200);


### PR DESCRIPTION
## 구현 내용

### 1) ProductService 테스트 추가
- 상품 생성 테스트
  - 정상 생성 성공 케이스 검증
  - 잘못된 날짜 포맷 입력 시 `INVALID_DATE_FORMAT` 예외 발생 검증
  - 중복된 상품명 입력 시 `PRODUCT_DUPLICATED` 예외 발생 검증
  - Repository `save()` 호출 여부 검증
- 상품 단일 조회 테스트
  - 정상 조회 시 ProductResponseDto 반환 확인
  - soft delete 되었거나 존재하지 않는 경우 예외 발생 검증
- 상품 전체 조회 테스트
  - soft delete 되지 않은 상품만 조회되는지 검증
- 상품 수정 테스트
  - `update()` 호출 후 값 정상 변경 여부 검증
  - Repository `save()` 호출 여부 검증
- 상품 삭제 테스트
  - soft delete 적용 후 `isDeleted = true` 상태 확인
  - Repository `save()` 호출 여부 검증

---

## 기술적 고려 사항
- LocalDateTime 파싱 로직을 중심으로 정상/예외 흐름을 모두 검증
- soft delete 정책이 조회/수정/삭제 전반에 일관되게 적용되는지 테스트로 보장
- Repository 의존성을 Mock 처리하여 Service 계층 비즈니스 로직에 테스트 범위 집중
- 정상 시나리오와 예외 시나리오를 함께 검증하여 서비스 로직 안정성 확보

---

## 관련 이슈
- closes #13
