### PR TITLE
feat: Order entity/dto/repository 구현

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/domain/order/entity/Order.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/entity/Order.java
@@ -1,0 +1,45 @@
+package com.supersonic.limitedstore.domain.order.entity;
+
+import com.supersonic.limitedstore.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Order extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "order_id")
+    private UUID id;
+
+    @Column(name = "member_id", nullable = false)
+    private UUID memberId;
+
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status", nullable = false)
+    private OrderStatus orderStatus;
+
+    public static Order create(UUID memberId, UUID productId) {
+        return Order.builder()
+            .memberId(memberId)
+            .productId(productId)
+            .orderStatus(OrderStatus.READY)
+            .build();
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/entity/OrderEventLog.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/entity/OrderEventLog.java
@@ -1,0 +1,43 @@
+package com.supersonic.limitedstore.domain.order.entity;
+
+import com.supersonic.limitedstore.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderEventLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "log_id")
+    private UUID id;
+
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(columnDefinition = "text")
+    private String message;
+
+    public static OrderEventLog of(UUID orderId, String eventType, String message) {
+        return OrderEventLog.builder()
+            .orderId(orderId)
+            .eventType(eventType)
+            .message(message)
+            .build();
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/entity/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.supersonic.limitedstore.domain.order.entity;
+
+public enum OrderStatus {
+    READY, // 주문 생성
+    PAID, // 결제 완료
+    CANCELLED, // 주문 취소
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/presentation/dto/req/OrderRequestDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/presentation/dto/req/OrderRequestDto.java
@@ -1,0 +1,19 @@
+package com.supersonic.limitedstore.domain.order.presentation.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderRequestDto {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private UUID productId;
+
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/presentation/dto/res/OrderResponseDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/presentation/dto/res/OrderResponseDto.java
@@ -1,0 +1,33 @@
+package com.supersonic.limitedstore.domain.order.presentation.dto.res;
+
+import com.supersonic.limitedstore.domain.order.entity.Order;
+import com.supersonic.limitedstore.domain.order.entity.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderResponseDto {
+    private UUID orderId;
+    private UUID memberId;
+    private UUID productId;
+    private OrderStatus orderStatus;
+    private LocalDateTime createdAt;
+
+    public static OrderResponseDto from(Order order) {
+        return OrderResponseDto.builder()
+            .orderId(order.getId())
+            .memberId(order.getMemberId())
+            .productId(order.getProductId())
+            .orderStatus(order.getOrderStatus())
+            .createdAt(order.getCreatedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/repository/OrderEventLogRepository.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/repository/OrderEventLogRepository.java
@@ -1,0 +1,10 @@
+package com.supersonic.limitedstore.domain.order.repository;
+
+import com.supersonic.limitedstore.domain.order.entity.OrderEventLog;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderEventLogRepository extends JpaRepository<OrderEventLog, UUID> {
+    List<OrderEventLog> findAllByOrderId(UUID orderId);
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/repository/OrderRepository.java
@@ -1,0 +1,13 @@
+package com.supersonic.limitedstore.domain.order.repository;
+
+import com.supersonic.limitedstore.domain.order.entity.Order;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+    Optional<Order> findByIdAndIsDeletedFalse(UUID id);
+
+    List<Order> findAllByMemberIdAndIsDeletedFalse(UUID memberId);
+}


### PR DESCRIPTION
## 구현 내용

### 1) Order 도메인(Entity) 추가
- Order 엔티티 생성
  - memberId, productId, orderStatus 필드 구성
  - BaseEntity 상속
    - createdAt, updatedAt, deletedAt, isDeleted 포함
  - 정적 팩토리 메서드 `create()` 적용
  - 한정판 정책에 따라 quantity 필드 제거
- OrderStatus enum 정의
  - READY / PAID / CANCELLED 상태 구성

---

### 2) OrderEventLog 도메인(Entity) 추가
- 주문 상태 변경 및 이벤트 기록을 위한 로그 엔티티 구성
- OrderEventLog 엔티티 생성
  - BaseEntity 상속
  - 정적 팩토리 메서드 `of()` 적용

---

### 3) DTO 구성
- 요청/응답에 필요한 필드만 최소화하여 DTO 구성

#### OrderRequestDto
- productId만 포함
- 1인 1개 구매 정책에 따라 quantity 제거
- `@NotNull` 검증 적용

#### OrderResponseDto
- 주문 생성 및 단건 조회 응답용 DTO
- orderId, memberId, productId, orderStatus, createdAt 포함
- 정적 메서드 `from()`을 통해 엔티티 변환

---

### 4) Repository 구성
- soft delete 정책을 반영한 조회 메서드 구성

#### OrderRepository
- `findByIdAndIsDeletedFalse()`
  - soft delete를 반영한 단건 조회
- `findAllByMemberIdAndIsDeletedFalse()`
  - 특정 회원의 유효한 주문 목록 조회

#### OrderEventLogRepository
- `findAllByOrderId()`
  - 특정 주문의 이벤트 로그 전체 조회

---

## 기술적 고려 사항
- soft delete 정책을 모든 조회 쿼리에 일관되게 반영
- quantity 필드를 제거하여 1인 1개 구매 정책을 도메인 레벨에서 명확히 표현
- Order 생성 시 정적 팩토리 메서드를 사용해 생성 책임을 엔티티에 위임
- 주문 상태 변경 이력 관리를 위해 OrderEventLog 도메인을 분리
- 향후 Service / Controller 계층 및 이벤트 기반 아키텍처 확장을 고려한 구조 설계

---

## 관련 이슈
- closes #17
