### PR TITLE
feat: 주문 기능 구현 (OrderService & OrderController)

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
+++ b/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
@@ -6,27 +6,32 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    // ===================== Common =====================
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 자원을 찾을 수 없습니다."),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다."),
+
+    // ===================== User =====================
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "이메일이 존재하지 않습니다."),
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-    NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임 입니다."),
+    NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     USER_DELETED(HttpStatus.FORBIDDEN, "탈퇴된 계정입니다."),
-
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
+
+    // ===================== Product =====================
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
-
-    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
     PRODUCT_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 상품명입니다."),
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+
+    // ===================== Order =====================
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
     DUPLICATE_ORDER(HttpStatus.BAD_REQUEST, "이미 주문한 상품입니다."),
-
-    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다." ),
-    ALREADY_PURCHASED(HttpStatus.CONFLICT, "해당 상품은 1인 1개만 구매할 수 있습니다.");
-
+    ALREADY_PURCHASED(HttpStatus.CONFLICT, "해당 상품은 1인 1개만 구매할 수 있습니다."),
+    ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "해당 주문에 대한 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
+++ b/src/main/java/com/supersonic/limitedstore/common/exception/ErrorCode.java
@@ -24,7 +24,9 @@ public enum ErrorCode {
     DUPLICATE_ORDER(HttpStatus.BAD_REQUEST, "이미 주문한 상품입니다."),
 
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다." ),;
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다." ),
+    ALREADY_PURCHASED(HttpStatus.CONFLICT, "해당 상품은 1인 1개만 구매할 수 있습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/supersonic/limitedstore/domain/order/entity/Order.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/entity/Order.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder
 @AllArgsConstructor
+@Table(name = "orders")
 @NoArgsConstructor
 public class Order extends BaseEntity {
     @Id
@@ -41,5 +43,9 @@ public class Order extends BaseEntity {
             .productId(productId)
             .orderStatus(OrderStatus.READY)
             .build();
+    }
+
+    public void updateStatus(OrderStatus newStatus) {
+        this.orderStatus = newStatus;
     }
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/order/entity/OrderEventLog.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/entity/OrderEventLog.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Entity
 @Getter
+@Table(name = "order_event_log")
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderEventLog extends BaseEntity {

--- a/src/main/java/com/supersonic/limitedstore/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/presentation/controller/OrderController.java
@@ -1,0 +1,53 @@
+package com.supersonic.limitedstore.domain.order.presentation.controller;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.domain.order.presentation.dto.req.OrderRequestDto;
+import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderResponseDto;
+import com.supersonic.limitedstore.domain.order.service.OrderService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ApiResponse<OrderResponseDto> createOrder(
+        @RequestBody @Valid OrderRequestDto dto,
+        HttpServletRequest request) {
+        UUID memberId = UUID.fromString((String) request.getAttribute("memberId"));
+        return orderService.createOrder(memberId, dto);
+    }
+
+    @GetMapping("/{orderId}")
+    public ApiResponse<OrderResponseDto> getOrder(@PathVariable UUID orderId) {
+        return orderService.getOrder(orderId);
+    }
+
+    @GetMapping
+    public ApiResponse<List<OrderResponseDto>> getMyOrders(HttpServletRequest request) {
+        UUID memberId = UUID.fromString((String) request.getAttribute("memberId"));
+        return orderService.getMyOrders(memberId);
+    }
+
+    @PostMapping("/{orderId}/cancel")
+    public ApiResponse<OrderResponseDto> cancelOrder(
+        @PathVariable UUID orderId,
+        HttpServletRequest request) {
+        UUID memberId = UUID.fromString((String) request.getAttribute("memberId"));
+        return orderService.cancelOrder(memberId, orderId);
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/repository/OrderRepository.java
@@ -10,4 +10,7 @@ public interface OrderRepository extends JpaRepository<Order, UUID> {
     Optional<Order> findByIdAndIsDeletedFalse(UUID id);
 
     List<Order> findAllByMemberIdAndIsDeletedFalse(UUID memberId);
+
+    boolean existsByMemberIdAndProductIdAndIsDeletedFalse(UUID memberId, UUID productId);
+
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderService.java
@@ -1,0 +1,126 @@
+package com.supersonic.limitedstore.domain.order.service;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
+import com.supersonic.limitedstore.domain.order.entity.Order;
+import com.supersonic.limitedstore.domain.order.entity.OrderEventLog;
+import com.supersonic.limitedstore.domain.order.entity.OrderStatus;
+import com.supersonic.limitedstore.domain.order.presentation.dto.req.OrderRequestDto;
+import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderResponseDto;
+import com.supersonic.limitedstore.domain.order.repository.OrderEventLogRepository;
+import com.supersonic.limitedstore.domain.order.repository.OrderRepository;
+import com.supersonic.limitedstore.domain.product.entity.Product;
+import com.supersonic.limitedstore.domain.product.repository.ProductRepository;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderEventLogRepository orderEventLogRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public ApiResponse<OrderResponseDto> createOrder(UUID memberId, OrderRequestDto dto) {
+
+        //상품 조회
+        Product product = productRepository.findByIdAndIsDeletedFalse(dto.getProductId())
+            .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 재고 확인
+        if (product.getStock() <= 0) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+
+        // 1인 1개 구매 제한
+        boolean alreadyOrdered = orderRepository.existsByMemberIdAndProductIdAndIsDeletedFalse(
+            memberId, dto.getProductId()
+        );
+
+        if (alreadyOrdered) {
+            throw new CustomException(ErrorCode.ALREADY_PURCHASED);
+        }
+
+        // 주문 생성
+        Order order = Order.create(memberId, dto.getProductId());
+        orderRepository.save(order);
+
+        // 재고 차감
+        product.decreaseStock();
+        productRepository.save(product);
+
+        // 주문 생성 로그
+        OrderEventLog log = OrderEventLog.of(
+            order.getId(),
+            "ORDER_CREATED",
+            "주문이 생성되었습니다."
+        );
+        orderEventLogRepository.save(log);
+
+        // response 변환 후 반환
+        return ApiResponse.ok(OrderResponseDto.from(order));
+    }
+
+    @Transactional(readOnly = true)
+    public ApiResponse<OrderResponseDto> getOrder(UUID orderId) {
+        Order order = orderRepository.findByIdAndIsDeletedFalse(orderId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        return ApiResponse.ok(OrderResponseDto.from(order));
+    }
+
+    // 트랜잭션에 대해서 이해를 못하고 있는 상태
+    // 어떤 경우에서 stream을 써야하나? 분명히 편한 기능이나 지금 상황은 이해를 못함
+    // map? 형상 변화로 기억하고 있는데
+    @Transactional(readOnly = true)
+    public ApiResponse<List<OrderResponseDto>> getMyOrders(UUID memberId) {
+        List<OrderResponseDto> orders = orderRepository
+            .findAllByMemberIdAndIsDeletedFalse(memberId)
+            .stream()
+            .map(OrderResponseDto::from)
+            .toList();
+
+        return ApiResponse.ok(orders);
+    }
+
+    @Transactional
+    public ApiResponse<OrderResponseDto> cancelOrder(UUID memberId, UUID orderId) {
+        //주문 확인
+        Order order = orderRepository.findByIdAndIsDeletedFalse(orderId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 주문자 확인
+        if (!order.getMemberId().equals(memberId)) {
+            throw new CustomException(ErrorCode.NO_PERMISSION);
+        }
+
+        // 취소된 주문인지 확인
+        if (order.getOrderStatus() == OrderStatus.CANCELLED) {
+            throw new CustomException(ErrorCode.ALREADY_CANCELLED);
+        }
+
+        // 주문 취소
+        order.updateStatus(OrderStatus.CANCELLED);
+        orderRepository.save(order);
+
+        Product product = productRepository.findByIdAndIsDeletedFalse(order.getProductId())
+            .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        product.increaseStock();
+        productRepository.save(product);
+
+        orderEventLogRepository.save(
+            OrderEventLog.of(order.getId(), "ORDER_CANCELLED", "주문이 취소되었습니다."));
+
+        return ApiResponse.ok(OrderResponseDto.from(order));
+    }
+
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
@@ -1,6 +1,8 @@
 package com.supersonic.limitedstore.domain.product.entity;
 
 import com.supersonic.limitedstore.common.entity.BaseEntity;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -48,5 +50,16 @@ public class Product extends BaseEntity {
         if (price != null) this.price = price;
         if (stock != null) this.stock = stock;
         if (releaseAt != null) this.releaseAt = releaseAt;
+    }
+
+    public void decreaseStock() {
+        if (this.stock <= 0) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+        this.stock -= 1;
+    }
+
+    public void increaseStock() {
+        this.stock += 1;
     }
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/user/service/UserService.java
@@ -70,7 +70,7 @@ public class UserService {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
-        String token = jwtTokenProvider.createToken(user.getEmail());
+        String token = jwtTokenProvider.createToken(user.getId(), user.getEmail());
 
         return ApiResponse.ok(
             UserLoginResponseDto.builder()

--- a/src/main/java/com/supersonic/limitedstore/security/JwtAuthFilter.java
+++ b/src/main/java/com/supersonic/limitedstore/security/JwtAuthFilter.java
@@ -1,5 +1,6 @@
 package com.supersonic.limitedstore.security;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,6 +24,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         HttpServletResponse response,
         FilterChain filterChain)
         throws ServletException, IOException {
+
         String authHeader = request.getHeader("Authorization");
 
         // 헤더가 없거나 제대로 안 왔으면 그 다음 필터 진행
@@ -36,9 +38,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         // 토큰이 유효한 경우에만 인증 정보 생성
         if (jwtTokenProvider.validate(token)) {
-            String email = jwtTokenProvider.getEmail(token);
+
+            Claims claims = jwtTokenProvider.getClaims(token);
+
+            String email = claims.get("email", String.class);
+            String memberId = claims.get("memberId", String.class);
 
             request.setAttribute("email", email);
+            request.setAttribute("memberId", memberId);
 
             // 인증 객체 생성
             UsernamePasswordAuthenticationToken authentication =
@@ -54,5 +61,4 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(request, response);
     }
-
 }

--- a/src/main/java/com/supersonic/limitedstore/security/JwtTokenProvider.java
+++ b/src/main/java/com/supersonic/limitedstore/security/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import jakarta.annotation.PostConstruct;
 import java.security.Key;
 import java.security.KeyStore;
 import java.util.Date;
+import java.util.UUID;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Component;
 
@@ -27,12 +28,13 @@ public class JwtTokenProvider {
     }
 
     // 토큰 생성
-    public String createToken(String email) {
+    public String createToken(UUID memberId, String email) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenValidTime);
 
         return Jwts.builder()
-            .setSubject(email) // 이메일을 subject에 저장
+            .claim("memberId", memberId.toString())
+            .claim("email", email)
             .setIssuedAt(now) // 토큰 발급 시간
             .setExpiration(expiry) // 만료시간
             .signWith(key, SignatureAlgorithm.HS256) // HS256 알고리즘으로 서명
@@ -61,5 +63,13 @@ public class JwtTokenProvider {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
     }
 }


### PR DESCRIPTION
## 구현 내용

### 1) OrderService 구현
- 주문 생성(createOrder)
  - memberId + productId 기반 주문 생성
  - 재고 부족 시 `OUT_OF_STOCK` 예외 반환
  - 1인 1개 정책 적용 → `ALREADY_PURCHASED` 검증
  - 주문 생성 후 상품 재고 차감
  - 주문 생성 이벤트 로그(OrderEventLog) 기록
- 주문 단건 조회(getOrder)
  - soft delete 되지 않은 주문만 조회
- 내 주문 목록 조회(getMyOrders)
  - READY, CANCELLED 상태를 포함한 모든 주문 조회
- 주문 취소(cancelOrder)
  - 주문자 본인 여부 검증 → `NO_PERMISSION` 예외 반환
  - 이미 취소된 주문인 경우 `ALREADY_CANCELLED` 예외 반환
  - 주문 취소 시 상품 재고 복구
  - 주문 취소 이벤트 로그 기록

---

### 2) OrderController 구현
- 주문 관련 REST API 구성
  - POST   `/v1/orders` : 주문 생성
  - GET    `/v1/orders/{orderId}` : 주문 단건 조회
  - GET    `/v1/orders` : 내 주문 전체 조회
  - POST   `/v1/orders/{orderId}/cancel` : 주문 취소
- JWT 필터에서 전달받은 memberId 기반으로 Service 호출

---

### 3) JWT 인증 구조 개선
- 토큰 생성 시 memberId, email을 claim으로 포함
- JwtAuthFilter에서 memberId, email 추출 후 request attribute에 저장
- 주문 기능 전반에서 memberId 기반 인증 및 권한 검증 가능하도록 개선

---

### 4) ErrorCode 수정
- `NO_PERMISSION` : "해당 주문에 대한 권한이 없습니다."
- `ALREADY_CANCELLED` : "이미 취소된 주문입니다."
- `ALREADY_PURCHASED` : "해당 상품은 1인 1개만 구매할 수 있습니다."

---

### 5) 엔티티 수정
- Order
  - 테이블명 예약어 충돌 방지를 위해 `@Table(name = "orders")` 적용
- OrderEventLog
  - `@Table(name = "order_event_logs")` 적용
- Product
  - 재고 관리를 위한 `increaseStock()`, `decreaseStock()` 메서드 추가

---

## 기술적 고려 사항
- soft delete 정책을 유지하여 주문 조회 및 취소 시 데이터 안정성 확보
- 주문 이벤트 로그를 별도 엔티티로 분리하여 상태 변경 이력 추적 가능
- 취소된 주문은 삭제하지 않고 상태값(CANCELLED)으로 관리하는 구조 채택
- JWT에 memberId를 포함시켜 Controller → Service 간 인증 흐름 단순화
- 재고 차감/복구 로직을 Product 도메인에 위임하여 책임 분리

---

## 관련 이슈
- closes #19
