### PR TITLE
Order 이벤트 로그 조회 기능 추가

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/domain/order/presentation/controller/OrderEventLogController.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/presentation/controller/OrderEventLogController.java
@@ -1,0 +1,33 @@
+package com.supersonic.limitedstore.domain.order.presentation.controller;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderEventLogResponseDto;
+import com.supersonic.limitedstore.domain.order.repository.OrderEventLogRepository;
+import com.supersonic.limitedstore.domain.order.service.OrderEventLogService;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/order-logs")
+@RequiredArgsConstructor
+public class OrderEventLogController {
+
+    private final OrderEventLogService orderEventLogService;
+
+    @GetMapping
+    public ApiResponse<List<OrderEventLogResponseDto>> getAllLogs() {
+        return orderEventLogService.getAllLogs();
+    }
+
+    @GetMapping("/{orderId}")
+    public ApiResponse<List<OrderEventLogResponseDto>> getLogsByOrderId(@PathVariable UUID orderId) {
+        return orderEventLogService.getLogsByOrderId(orderId);
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/presentation/dto/res/OrderEventLogResponseDto.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/presentation/dto/res/OrderEventLogResponseDto.java
@@ -1,0 +1,32 @@
+package com.supersonic.limitedstore.domain.order.presentation.dto.res;
+
+import com.supersonic.limitedstore.domain.order.entity.OrderEventLog;
+import com.supersonic.limitedstore.domain.order.entity.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderEventLogResponseDto {
+    private UUID logId;
+    private UUID orderId;
+    private String eventType;
+    private String message;
+    private LocalDateTime createdAt;
+
+    public static OrderEventLogResponseDto from(OrderEventLog log) {
+        return OrderEventLogResponseDto.builder()
+            .logId(log.getId())
+            .orderId(log.getOrderId())
+            .eventType(log.getEventType())
+            .message(log.getMessage())
+            .createdAt(log.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderEventLogService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderEventLogService.java
@@ -1,0 +1,41 @@
+package com.supersonic.limitedstore.domain.order.service;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.domain.order.entity.OrderEventLog;
+import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderEventLogResponseDto;
+import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderResponseDto;
+import com.supersonic.limitedstore.domain.order.repository.OrderEventLogRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderEventLogService {
+
+    private final OrderEventLogRepository orderEventLogRepository;
+
+    @Transactional(readOnly = true)
+    public ApiResponse<List<OrderEventLogResponseDto>> getAllLogs() {
+        List<OrderEventLogResponseDto> logs =
+            orderEventLogRepository.findAll()
+                .stream()
+                .map(OrderEventLogResponseDto::from)
+                .toList();
+
+        return ApiResponse.ok(logs);
+    }
+
+    @Transactional(readOnly = true)
+    public ApiResponse<List<OrderEventLogResponseDto>> getLogsByOrderId(UUID orderId) {
+        List<OrderEventLogResponseDto> logs =
+            orderEventLogRepository.findAllByOrderId(orderId)
+                .stream()
+                .map(OrderEventLogResponseDto::from)
+                .toList();
+
+        return ApiResponse.ok(logs);
+    }
+}


### PR DESCRIPTION
## 구현 내용

### 1) OrderEventLogService 추가
- 주문 이벤트 로그 조회를 담당하는 Service 계층 구현
- 전체 주문 이벤트 로그 조회 기능 제공
- 특정 주문 ID 기준 이벤트 로그 조회 기능 제공
- 조회 전용 서비스로 `@Transactional(readOnly = true)` 적용

---

### 2) OrderEventLogController 추가
- 주문 이벤트 로그 조회용 API 엔드포인트 구현
- 전체 로그 조회 API
  - GET `/v1/order-logs`
- 주문별 로그 조회 API
  - GET `/v1/order-logs/{orderId}`

---

### 3) OrderEventLogResponseDto 구현
- 주문 이벤트 로그 응답 전용 DTO 구성
- logId, orderId, eventType, message, createdAt 필드 포함
- 엔티티 → DTO 변환을 위한 정적 팩토리 메서드 `from()` 제공

---

### 4) Repository 연동
- OrderEventLogRepository를 통한 로그 데이터 조회
- JPA 네이밍 규칙을 활용한 `findAllByOrderId()` 메서드 사용

---

## 기술적 고려 사항
- 주문 상태 변경 이력을 관리하기 위해 OrderEventLog를 별도 도메인으로 분리
- Order 엔티티와 책임을 분리하여 SRP(단일 책임 원칙) 준수
- 로그 조회 기능을 읽기 전용 트랜잭션으로 처리하여 성능 및 안정성 확보
- 향후 MSA 또는 이벤트 기반 아키텍처 확장을 고려한 구조 설계

---

## 관련 이슈
- closes #21
