### PR TITLE
test: OrderService 비즈니스 로직 단위 테스트 추가

### DIFF
--- a/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
@@ -1,0 +1,247 @@
+package com.supersonic.limitedstore.order.service;
+
+import com.supersonic.limitedstore.common.dto.ApiResponse;
+import com.supersonic.limitedstore.common.exception.CustomException;
+import com.supersonic.limitedstore.common.exception.ErrorCode;
+import com.supersonic.limitedstore.domain.order.entity.Order;
+import com.supersonic.limitedstore.domain.order.entity.OrderStatus;
+import com.supersonic.limitedstore.domain.order.presentation.dto.req.OrderRequestDto;
+import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderResponseDto;
+import com.supersonic.limitedstore.domain.order.repository.OrderEventLogRepository;
+import com.supersonic.limitedstore.domain.order.repository.OrderRepository;
+import com.supersonic.limitedstore.domain.order.service.OrderService;
+import com.supersonic.limitedstore.domain.product.entity.Product;
+import com.supersonic.limitedstore.domain.product.repository.ProductRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderServiceTest {
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private OrderEventLogRepository orderEventLogRepository;
+
+    private UUID memberId;
+    private UUID productId;
+    private UUID orderId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+        orderId = UUID.randomUUID();
+    }
+
+
+    @Test
+    void 주문_생성_성공() {
+        OrderRequestDto dto = OrderRequestDto.builder()
+            .productId(productId)
+            .build();
+
+        Product product = Product.builder()
+            .id(productId)
+            .stock(10)
+            .build();
+
+        when(productRepository.findByIdAndIsDeletedFalse(productId))
+            .thenReturn(Optional.of(product));
+
+        when(orderRepository.existsByMemberIdAndProductIdAndIsDeletedFalse(memberId, productId))
+            .thenReturn(false);
+
+        when(orderRepository.save(any(Order.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ApiResponse<OrderResponseDto> response =
+            orderService.createOrder(memberId, dto);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getData().getOrderStatus()).isEqualTo(OrderStatus.READY);
+        assertThat(product.getStock()).isEqualTo(9);
+
+        verify(orderEventLogRepository).save(any());
+    }
+
+    @Test
+    void 주문_생성_실패_상품없음() {
+        OrderRequestDto dto = OrderRequestDto.builder()
+            .productId(productId)
+            .build();
+
+        when(productRepository.findByIdAndIsDeletedFalse(productId))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            orderService.createOrder(memberId, dto))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 주문_생성_실패_재고없음() {
+        OrderRequestDto dto = OrderRequestDto.builder()
+            .productId(productId)
+            .build();
+
+        Product product = Product.builder()
+            .id(productId)
+            .stock(0)
+            .build();
+
+        when(productRepository.findByIdAndIsDeletedFalse(productId))
+            .thenReturn(Optional.of(product));
+
+        assertThatThrownBy(() ->
+            orderService.createOrder(memberId, dto))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.OUT_OF_STOCK.getMessage());
+    }
+
+    @Test
+    void 주문_생성_실패_이미구매함() {
+        OrderRequestDto dto = OrderRequestDto.builder()
+            .productId(productId)
+            .build();
+
+        Product product = Product.builder()
+            .id(productId)
+            .stock(10)
+            .build();
+
+        when(productRepository.findByIdAndIsDeletedFalse(productId))
+            .thenReturn(Optional.of(product));
+
+        when(orderRepository.existsByMemberIdAndProductIdAndIsDeletedFalse(memberId, productId))
+            .thenReturn(true);
+
+        assertThatThrownBy(() ->
+            orderService.createOrder(memberId, dto))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.ALREADY_PURCHASED.getMessage());
+    }
+
+    @Test
+    void 주문_단건_조회_성공() {
+        Order order = Order.builder()
+            .id(orderId)
+            .memberId(memberId)
+            .productId(productId)
+            .orderStatus(OrderStatus.READY)
+            .build();
+
+        when(orderRepository.findByIdAndIsDeletedFalse(orderId))
+            .thenReturn(Optional.of(order));
+
+        ApiResponse<OrderResponseDto> response =
+            orderService.getOrder(orderId);
+
+        assertThat(response.getData().getOrderId()).isEqualTo(orderId);
+    }
+
+    @Test
+    void 주문_단건_조회_실패() {
+        when(orderRepository.findByIdAndIsDeletedFalse(orderId))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> orderService.getOrder(orderId))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 내_주문_목록_조회() {
+        when(orderRepository.findAllByMemberIdAndIsDeletedFalse(memberId))
+            .thenReturn(List.of());
+
+        ApiResponse<List<OrderResponseDto>> response =
+            orderService.getMyOrders(memberId);
+
+        assertThat(response.getData()).isEmpty();
+    }
+
+
+    @Test
+    void 주문_취소_성공() {
+        Order order = Order.builder()
+            .id(orderId)
+            .memberId(memberId)
+            .productId(productId)
+            .orderStatus(OrderStatus.READY)
+            .build();
+
+        Product product = Product.builder()
+            .id(productId)
+            .stock(5)
+            .build();
+
+        when(orderRepository.findByIdAndIsDeletedFalse(orderId))
+            .thenReturn(Optional.of(order));
+
+        when(productRepository.findByIdAndIsDeletedFalse(productId))
+            .thenReturn(Optional.of(product));
+
+        ApiResponse<OrderResponseDto> response =
+            orderService.cancelOrder(memberId, orderId);
+
+        assertThat(response.getData().getOrderStatus())
+            .isEqualTo(OrderStatus.CANCELLED);
+        assertThat(product.getStock()).isEqualTo(6);
+
+        verify(orderEventLogRepository).save(any());
+    }
+
+    @Test
+    void 주문_취소_실패_권한없음() {
+        Order order = Order.builder()
+            .id(orderId)
+            .memberId(UUID.randomUUID())
+            .orderStatus(OrderStatus.READY)
+            .build();
+
+        when(orderRepository.findByIdAndIsDeletedFalse(orderId))
+            .thenReturn(Optional.of(order));
+
+        assertThatThrownBy(() ->
+            orderService.cancelOrder(memberId, orderId))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NO_PERMISSION.getMessage());
+    }
+
+    @Test
+    void 주문_취소_실패_이미취소됨() {
+        Order order = Order.builder()
+            .id(orderId)
+            .memberId(memberId)
+            .orderStatus(OrderStatus.CANCELLED)
+            .build();
+
+        when(orderRepository.findByIdAndIsDeletedFalse(orderId))
+            .thenReturn(Optional.of(order));
+
+        assertThatThrownBy(() ->
+            orderService.cancelOrder(memberId, orderId))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.ALREADY_CANCELLED.getMessage());
+    }
+}

--- a/src/test/java/com/supersonic/limitedstore/user/service/UserServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/user/service/UserServiceTest.java
@@ -126,7 +126,7 @@ public class UserServiceTest {
 
         when(userRepository.findByEmail(dto.getEmail())).thenReturn(Optional.of(user));
         when(passwordEncoder.matches(dto.getPassword(), user.getPassword())).thenReturn(true);
-        when(jwtTokenProvider.createToken(any())).thenReturn("token");
+        when(jwtTokenProvider.createToken(any(), any())).thenReturn("token");
 
         //when
         ApiResponse<UserLoginResponseDto> result = userService.login(dto);


### PR DESCRIPTION
## 구현 내용

### 1) OrderService 테스트 코드 추가
- OrderService 단위 테스트 클래스 `OrderServiceTest` 작성
- Mockito를 활용하여 Repository 의존성 Mock 처리
- Service 계층의 비즈니스 로직을 중심으로 테스트 구성

---

### 2) 주문 생성(createOrder) 테스트
#### 성공 케이스
- 상품이 존재하고 재고가 충분한 경우 주문 생성 성공
- 1인 1개 구매 정책을 만족하는 경우 정상 주문 처리
- 주문 생성 시 다음 로직이 정상적으로 수행되는지 검증
  - 주문 저장
  - 상품 재고 차감
  - 주문 이벤트 로그 저장

#### 실패 케이스
- 상품이 존재하지 않는 경우 → `PRODUCT_NOT_FOUND`
- 상품 재고가 0인 경우 → `OUT_OF_STOCK`
- 이미 동일 상품을 주문한 경우 → `ALREADY_PURCHASED`

---

### 3) 주문 조회(getOrder, getMyOrders) 테스트
#### 단건 조회(getOrder)
- 주문이 존재하는 경우 정상 조회 성공
- 주문이 존재하지 않는 경우 → `ORDER_NOT_FOUND`

#### 목록 조회(getMyOrders)
- 특정 회원의 주문 목록 정상 조회
- 주문이 없는 경우 빈 리스트 반환 여부 검증

---

### 4) 주문 취소(cancelOrder) 테스트
#### 성공 케이스
- 본인의 주문이며 취소되지 않은 상태인 경우 정상 취소
- 주문 상태가 `CANCELLED`로 변경되는지 검증
- 상품 재고가 증가하는지 검증
- 주문 취소 이벤트 로그 저장 여부 검증

#### 실패 케이스
- 주문이 존재하지 않는 경우 → `ORDER_NOT_FOUND`
- 주문자가 아닌 경우 → `NO_PERMISSION`
- 이미 취소된 주문인 경우 → `ALREADY_CANCELLED`

---

## 기술적 고려 사항
- Controller 계층과 분리하여 Service 계층의 비즈니스 로직만 검증
- Repository 메서드 호출 여부를 `verify()`로 확인하여
  의도한 로직 흐름이 실행되는지 검증
- 성공 / 실패 케이스를 명확히 분리하여
  도메인 규칙이 테스트 코드에 드러나도록 구성

---

## 관련 이슈
- closes #23 
