### PR TITLE
Feature: Order-Product Feign 연동 및 MSA 전환 구조 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,24 @@ Limited Store는 한정 수량 상품 주문을 가정한 개인 백엔드 프�
 - JWT 인증 필터는 통과되었다고 가정하고 requestAttr로 인증 정보를 주입
 - Service에서 발생한 예외가 GlobalExceptionHandler를 통해
   HTTP 상태 코드와 공통 응답 포맷으로 변환되는지 검증
+
+## Why Order ↔ Product Only(MSA Transition)
+본 프로젝트는 완전한 MSA 구현이 목적이 아니라,
+서비스 분리 기준과 책임 경계를 설명할 수 있는 구조를 만드는 것을 목표로 했습니다.
+
+### 왜 Order ↔ Product만 분리했는가
+- 주문 생성 시 Order의 상품의 존재 여부와 재고 상태에 의존합니다.
+- 이에 따라 상품의 존재 여부 판단 책임을 Product 서비스로 분리했습니다.
+
+### 현재 구조 (과도기 상태)
+- 상품 존재 여부: Product 서비스 책임 (Feign Client 통신)
+- 재고 확인 및 차감: 모놀리식 트랜젝션 유지
+
+이는 모놀리식에서 MSA로 전환하는 과도기적 구조로,
+재고 차감 API 분리 시 Product 엔티티 및 Repository 의존을 제거할 수 있도록
+구조를 의도적으로 열어두었습니다.
+
+### 목표가 아닌 것
+- 완전한 MSA 구성
+- Gateway, Eureka 등 인프라 구성
+- 분산 트랜젝션 처리

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Limited Store
 
 ## 프로젝트 개요
-Limited Store는 한정 수량 상품 주문을 가정한 개인 백엔드 프로젝트입니다.
-모놀리식 구조로 CRUD와 비즈니스 로직을 구현한 뒤,
+Limited Store는 한정 수량 상품 주문을 가정한 개인 백엔드 프로젝트입니다.  
+모놀리식 구조로 CRUD와 비즈니스 로직을 구현한 뒤,  
 테스트와 구조 이해를 중심으로 최소 수준의 MSA 분리를 경험하는 것을 목표로 했습니다.
 
 ## 기술 스택
@@ -11,6 +11,7 @@ Limited Store는 한정 수량 상품 주문을 가정한 개인 백엔드 프�
 - Spring Data JPA
 - JUnit5 / Mockito
 - Spring MVC Test
+- Spring Cloud OpenFeign
 
 ## 테스트 전략
 본 프로젝트에서는 계층별 책임을 명확히 하기 위해 테스트를 분리했습니다.
@@ -25,26 +26,35 @@ Limited Store는 한정 수량 상품 주문을 가정한 개인 백엔드 프�
 - @WebMvcTest 기반으로 Controller 계층만 로딩
 - Service는 @MockitoBean으로 대체
 - JWT 인증 필터는 통과되었다고 가정하고 requestAttr로 인증 정보를 주입
-- Service에서 발생한 예외가 GlobalExceptionHandler를 통해
+- Service에서 발생한 예외가 GlobalExceptionHandler를 통해  
   HTTP 상태 코드와 공통 응답 포맷으로 변환되는지 검증
 
-## Why Order ↔ Product Only(MSA Transition)
-본 프로젝트는 완전한 MSA 구현이 목적이 아니라,
-서비스 분리 기준과 책임 경계를 설명할 수 있는 구조를 만드는 것을 목표로 했습니다.
+---
 
-### 왜 Order ↔ Product만 분리했는가
-- 주문 생성 시 Order의 상품의 존재 여부와 재고 상태에 의존합니다.
-- 이에 따라 상품의 존재 여부 판단 책임을 Product 서비스로 분리했습니다.
+## MSA Transition Structure (Order ↔ Product)
 
-### 현재 구조 (과도기 상태)
-- 상품 존재 여부: Product 서비스 책임 (Feign Client 통신)
-- 재고 확인 및 차감: 모놀리식 트랜젝션 유지
+아래 구조는 모놀리식에서 MSA로 전환하는 **과도기적 설계 상태**를 나타냅니다.  
+현재는 상품 존재 여부만 Product 서비스로 분리하고,  
+재고 차감은 로컬 트랜잭션으로 유지하고 있습니다.
 
-이는 모놀리식에서 MSA로 전환하는 과도기적 구조로,
-재고 차감 API 분리 시 Product 엔티티 및 Repository 의존을 제거할 수 있도록
-구조를 의도적으로 열어두었습니다.
+```mermaid
+flowchart LR
 
-### 목표가 아닌 것
-- 완전한 MSA 구성
-- Gateway, Eureka 등 인프라 구성
-- 분산 트랜젝션 처리
+Client[Client / Frontend]
+
+subgraph Monolith Phase
+    OrderService[Order Service]
+    ProductRepository[(Product Repository)]
+end
+
+subgraph MSA Phase (Transition)
+    ProductService[Product Service]
+end
+
+Client --> OrderService
+
+OrderService -->|Feign: exists(productId)| ProductService
+
+OrderService -->|Local Transaction| ProductRepository
+
+ProductService -->|Manages Product State| ProductService

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'    // ★ 반드시 여기 버전을 바꿔야 함
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.3.5'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.supersonic'
@@ -19,12 +19,16 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web' // webmvc 대신 web로 변경 권장
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
+
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
@@ -41,4 +45,14 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+ext {
+    set('springCloudVersion', "2023.0.1")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.4"
+    }
 }

--- a/src/main/java/com/supersonic/limitedstore/LimitedStoreApplication.java
+++ b/src/main/java/com/supersonic/limitedstore/LimitedStoreApplication.java
@@ -3,9 +3,11 @@ package com.supersonic.limitedstore;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableFeignClients
 public class LimitedStoreApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/supersonic/limitedstore/domain/order/infrastructure/client/ProductClient.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/infrastructure/client/ProductClient.java
@@ -1,0 +1,13 @@
+package com.supersonic.limitedstore.domain.order.infrastructure.client;
+
+
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "product-service")
+public interface ProductClient {
+    @GetMapping("/products/{productId}/exists")
+    boolean exists(@PathVariable UUID productId);
+}

--- a/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderService.java
@@ -25,19 +25,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 @RequiredArgsConstructor
 public class OrderService {
 
-    /**
-     * OrderService는 현재 모놀리식 -> MSA 전환 과도기 상태
-     *
-     * - 상품 존재 여부 : ProductClient (외부 서비스 책임)
-     * - 재고 확인/차감 : ProductRepository (로컬 트랜젝션 유지)
-     *
-     * 재고 차감 API 분리 시 Product 엔티티 및 Repository 의존은 제거
-     */
-
-
     private final OrderRepository orderRepository;
     private final OrderEventLogRepository orderEventLogRepository;
-    private final ProductRepository productRepository; // 재고 차감 API 분리 시 제거 예정
+    private final ProductRepository productRepository;
     private final ProductClient productClient;
 
     @Transactional
@@ -49,16 +39,13 @@ public class OrderService {
             throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
         }
 
-        // 재고 차감 API 분리 시 productRepository 제거 예정
         Product product = productRepository.findByIdAndIsDeletedFalse(dto.getProductId())
             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        // 재고 확인
         if (product.getStock() <= 0) {
             throw new CustomException(ErrorCode.OUT_OF_STOCK);
         }
 
-        // 1인 1개 구매 제한
         boolean alreadyOrdered = orderRepository.existsByMemberIdAndProductIdAndIsDeletedFalse(
             memberId, dto.getProductId()
         );
@@ -67,17 +54,12 @@ public class OrderService {
             throw new CustomException(ErrorCode.ALREADY_PURCHASED);
         }
 
-        // 주문 생성
         Order order = Order.create(memberId, dto.getProductId());
         orderRepository.save(order);
 
-        // 현재 재고 차감은 OrderCreate 내부에 존재
-        // 이는 모놀리식 구조를 유지하기 위한 과도기 상태이며,
-        // 재고 차감 API(Product 서비스) 분리 시 제거 예정
         product.decreaseStock();
         productRepository.save(product);
 
-        // 주문 생성 로그
         OrderEventLog log = OrderEventLog.of(
             order.getId(),
             "ORDER_CREATED",
@@ -85,7 +67,6 @@ public class OrderService {
         );
         orderEventLogRepository.save(log);
 
-        // response 변환 후 반환
         return ApiResponse.ok(OrderResponseDto.from(order));
     }
 
@@ -97,9 +78,6 @@ public class OrderService {
         return ApiResponse.ok(OrderResponseDto.from(order));
     }
 
-    // 트랜잭션에 대해서 이해를 못하고 있는 상태
-    // 어떤 경우에서 stream을 써야하나? 분명히 편한 기능이나 지금 상황은 이해를 못함
-    // map? 형상 변화로 기억하고 있는데
     @Transactional(readOnly = true)
     public ApiResponse<List<OrderResponseDto>> getMyOrders(UUID memberId) {
         List<OrderResponseDto> orders = orderRepository
@@ -113,21 +91,18 @@ public class OrderService {
 
     @Transactional
     public ApiResponse<OrderResponseDto> cancelOrder(UUID memberId, UUID orderId) {
-        //주문 확인
+
         Order order = orderRepository.findByIdAndIsDeletedFalse(orderId)
             .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 주문자 확인
         if (!order.getMemberId().equals(memberId)) {
             throw new CustomException(ErrorCode.NO_PERMISSION);
         }
 
-        // 취소된 주문인지 확인
         if (order.getOrderStatus() == OrderStatus.CANCELLED) {
             throw new CustomException(ErrorCode.ALREADY_CANCELLED);
         }
 
-        // 주문 취소
         order.updateStatus(OrderStatus.CANCELLED);
         orderRepository.save(order);
 

--- a/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/order/service/OrderService.java
@@ -6,6 +6,7 @@ import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.order.entity.Order;
 import com.supersonic.limitedstore.domain.order.entity.OrderEventLog;
 import com.supersonic.limitedstore.domain.order.entity.OrderStatus;
+import com.supersonic.limitedstore.domain.order.infrastructure.client.ProductClient;
 import com.supersonic.limitedstore.domain.order.presentation.dto.req.OrderRequestDto;
 import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderResponseDto;
 import com.supersonic.limitedstore.domain.order.repository.OrderEventLogRepository;
@@ -24,14 +25,31 @@ import org.springframework.web.bind.annotation.RequestBody;
 @RequiredArgsConstructor
 public class OrderService {
 
+    /**
+     * OrderService는 현재 모놀리식 -> MSA 전환 과도기 상태
+     *
+     * - 상품 존재 여부 : ProductClient (외부 서비스 책임)
+     * - 재고 확인/차감 : ProductRepository (로컬 트랜젝션 유지)
+     *
+     * 재고 차감 API 분리 시 Product 엔티티 및 Repository 의존은 제거
+     */
+
+
     private final OrderRepository orderRepository;
     private final OrderEventLogRepository orderEventLogRepository;
-    private final ProductRepository productRepository;
+    private final ProductRepository productRepository; // 재고 차감 API 분리 시 제거 예정
+    private final ProductClient productClient;
 
     @Transactional
     public ApiResponse<OrderResponseDto> createOrder(UUID memberId, OrderRequestDto dto) {
 
-        //상품 조회
+        UUID productId = dto.getProductId();
+
+        if (!productClient.exists(productId)) {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        // 재고 차감 API 분리 시 productRepository 제거 예정
         Product product = productRepository.findByIdAndIsDeletedFalse(dto.getProductId())
             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
@@ -53,7 +71,9 @@ public class OrderService {
         Order order = Order.create(memberId, dto.getProductId());
         orderRepository.save(order);
 
-        // 재고 차감
+        // 현재 재고 차감은 OrderCreate 내부에 존재
+        // 이는 모놀리식 구조를 유지하기 위한 과도기 상태이며,
+        // 재고 차감 API(Product 서비스) 분리 시 제거 예정
         product.decreaseStock();
         productRepository.save(product);
 

--- a/src/main/java/com/supersonic/limitedstore/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/presentation/controller/ProductController.java
@@ -55,4 +55,10 @@ public class ProductController {
     public void deleteProduct(@PathVariable("id") UUID id) {
         productService.deleteProduct(id);
     }
+
+
+    @GetMapping("/{id}/exists")
+    public boolean exists(@PathVariable UUID id) {
+        return productService.exists(id);
+    }
 }

--- a/src/main/java/com/supersonic/limitedstore/domain/product/service/ProductService.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/service/ProductService.java
@@ -111,4 +111,8 @@ public class ProductService {
         productRepository.save(product);
     }
 
+    public boolean exists(UUID productId) {
+        return productRepository.existsById(productId);
+    }
+
 }

--- a/src/test/java/com/supersonic/limitedstore/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/supersonic/limitedstore/order/controller/OrderControllerTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.*;
@@ -31,10 +31,10 @@ public class OrderControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private OrderService orderService;
 
-    @MockitoBean
+    @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
     @Autowired

--- a/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
@@ -68,6 +68,9 @@ public class OrderServiceTest {
             .stock(10)
             .build();
 
+        when(productClient.exists(productId))
+            .thenReturn(true);
+
         when(productRepository.findByIdAndIsDeletedFalse(productId))
             .thenReturn(Optional.of(product));
 
@@ -113,6 +116,9 @@ public class OrderServiceTest {
             .stock(0)
             .build();
 
+        when(productClient.exists(productId))
+            .thenReturn(true);
+
         when(productRepository.findByIdAndIsDeletedFalse(productId))
             .thenReturn(Optional.of(product));
 
@@ -132,6 +138,9 @@ public class OrderServiceTest {
             .id(productId)
             .stock(10)
             .build();
+
+        when(productClient.exists(productId))
+            .thenReturn(true);
 
         when(productRepository.findByIdAndIsDeletedFalse(productId))
             .thenReturn(Optional.of(product));

--- a/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
@@ -5,6 +5,7 @@ import com.supersonic.limitedstore.common.exception.CustomException;
 import com.supersonic.limitedstore.common.exception.ErrorCode;
 import com.supersonic.limitedstore.domain.order.entity.Order;
 import com.supersonic.limitedstore.domain.order.entity.OrderStatus;
+import com.supersonic.limitedstore.domain.order.infrastructure.client.ProductClient;
 import com.supersonic.limitedstore.domain.order.presentation.dto.req.OrderRequestDto;
 import com.supersonic.limitedstore.domain.order.presentation.dto.res.OrderResponseDto;
 import com.supersonic.limitedstore.domain.order.repository.OrderEventLogRepository;
@@ -37,6 +38,9 @@ public class OrderServiceTest {
 
     @Mock
     private ProductRepository productRepository;
+
+    @Mock
+    private ProductClient productClient;
 
     @Mock
     private OrderEventLogRepository orderEventLogRepository;
@@ -89,8 +93,8 @@ public class OrderServiceTest {
             .productId(productId)
             .build();
 
-        when(productRepository.findByIdAndIsDeletedFalse(productId))
-            .thenReturn(Optional.empty());
+        when(productClient.exists(any(UUID.class)))
+        .thenReturn(false);
 
         assertThatThrownBy(() ->
             orderService.createOrder(memberId, dto))

--- a/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
+++ b/src/test/java/com/supersonic/limitedstore/order/service/OrderServiceTest.java
@@ -96,7 +96,7 @@ public class OrderServiceTest {
             .productId(productId)
             .build();
 
-        when(productClient.exists(any(UUID.class)))
+        when(productClient.exists(productId))
         .thenReturn(false);
 
         assertThatThrownBy(() ->

--- a/src/test/java/com/supersonic/limitedstore/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/supersonic/limitedstore/product/controller/ProductControllerTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.*;
@@ -33,10 +33,10 @@ public class ProductControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private ProductService productService;
 
-    @MockitoBean
+    @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
     @Autowired

--- a/src/test/java/com/supersonic/limitedstore/user/controller/UserControllerTest.java
+++ b/src/test/java/com/supersonic/limitedstore/user/controller/UserControllerTest.java
@@ -15,12 +15,11 @@ import com.supersonic.limitedstore.domain.user.service.UserService;
 import com.supersonic.limitedstore.security.JwtTokenProvider;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -37,10 +36,10 @@ class UserControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private UserService userService;
 
-    @MockitoBean
+    @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
     @Autowired


### PR DESCRIPTION
## 구현 내용

### 1) Order → Product 연동 방식 전환
- 상품 존재 확인 로직을 Feign Client 기반 호출로 변경
- 서비스 간 REST 통신을 통해 Product 서비스 상태 확인

---

### 2) 재고 처리 과도기 구조 유지
- 재고 차감/복구는 Order 서비스 로컬 트랜잭션에서 처리
- MSA 전환 초기 단계에서 일관성/복잡도 균형을 고려해 과도기 구조 유지
- 향후 재고 API 분리 시 ProductRepository 의존 제거 가능하도록 구조를 열어둠

---

### 3) README 문서화
- MSA 전환 의도 및 서비스 분리 목적 명시
- 통신 실패 시 판단 기준(상품 미존재/재고 부족 → 주문 실패) 문서화

---

### 4) 테스트 코드 보완
- OrderService 테스트에 Feign 기반 상품 존재 확인 케이스 반영
- 통신 실패 시 예외 흐름 검증 추가

---

## 기술적 고려 사항
- Feign Client를 통해 서비스 의존성을 “호출 인터페이스”로 분리
- 재고 처리를 로컬 트랜잭션으로 유지하여 전환 단계 복잡도/리스크 관리
- 통신 실패 시 정합성 깨짐을 방지하기 위해 명확한 실패 기준을 적용

## 관련 이슈
- closes  #29

