### PR TITLE
test: 동시성 문제 재현 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+        events "passed", "skipped", "failed"
+    }
 }
 
 ext {

--- a/src/test/java/com/supersonic/limitedstore/order/StockConcurrencyTest.java
+++ b/src/test/java/com/supersonic/limitedstore/order/StockConcurrencyTest.java
@@ -1,0 +1,87 @@
+package com.supersonic.limitedstore.order;
+
+import com.supersonic.limitedstore.domain.order.infrastructure.client.ProductClient;
+import com.supersonic.limitedstore.domain.order.presentation.dto.req.OrderRequestDto;
+import com.supersonic.limitedstore.domain.order.repository.OrderRepository;
+import com.supersonic.limitedstore.domain.order.service.OrderService;
+import com.supersonic.limitedstore.domain.product.entity.Product;
+import com.supersonic.limitedstore.domain.product.repository.ProductRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("local")
+public class StockConcurrencyTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @MockBean
+    private ProductClient productClient;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository.deleteAll();
+        productRepository.deleteAll();
+    }
+
+    @Test
+    void 동시에_100명_주문시_재고_음수() throws InterruptedException {
+        Product product = Product.builder()
+            .name("테스트상품")
+            .description("테스트")
+            .price(10000)
+            .stock(10)
+            .releaseAt(LocalDateTime.now())
+            .build();
+        productRepository.save(product);
+
+        given(productClient.exists(product.getId())).willReturn(true);
+
+        int threadCount = 100;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+
+        for (int i = 0; i < threadCount; i++) {
+            UUID memberId = UUID.randomUUID();
+            OrderRequestDto dto = OrderRequestDto.builder()
+                .productId(product.getId())
+                .build();
+
+            executorService.submit(() -> {
+                try {
+                    orderService.createOrder(memberId, dto);
+                } catch (Exception e) {
+
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Product result = productRepository.findById(product.getId()).orElseThrow();
+        System.out.println("최종 재고: " + result.getStock());
+        assertThat(result.getStock()).isGreaterThanOrEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 구현 내용

### 1) 동시성 문제 재현 테스트 작성
- CountDownLatch와 ExecutorService를 활용한 동시 요청 시뮬레이션 구현
- 100개 스레드로 재고 10개짜리 상품에 동시 주문 요청
- @Transactional 미적용 시 재고 음수(-38) 발생 확인

### 2) 트랜잭션 기반 정합성 보장 확인
- @Transactional 적용 시 재고 정합성 보장 확인
- 재고 초과 요청은 OUT_OF_STOCK 예외로 처리되어 음수 방지

### 3) 테스트 환경 구성
- @SpringBootTest + @ActiveProfiles("local") 기반 통합 테스트
- @MockBean으로 ProductClient 외부 통신 Mock 처리
- @BeforeEach로 테스트 데이터 초기화

---

## 기술적 고려 사항
- 단일 서버 환경에서는 @Transactional만으로 동시성 문제 방어 가능
- 분산 환경(다중 서버)에서는 트랜잭션만으로 정합성 보장 불가
- 향후 낙관적 락(@Version) 및 비관적 락(@Lock) 적용을 통한 동시성 제어 예정

---

## 관련 이슈
- closes #35 