### PR TITLE
Feature: 낙관적 락 적용으로 동시성 문제 해결

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
+++ b/src/main/java/com/supersonic/limitedstore/domain/product/entity/Product.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -28,6 +29,9 @@ public class Product extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column()
     private UUID id;
+
+    @Version
+    private Long version;
 
     @Column(nullable = false, unique = true)
     private String name;

--- a/src/test/java/com/supersonic/limitedstore/order/StockConcurrencyTest.java
+++ b/src/test/java/com/supersonic/limitedstore/order/StockConcurrencyTest.java
@@ -2,6 +2,7 @@ package com.supersonic.limitedstore.order;
 
 import com.supersonic.limitedstore.domain.order.infrastructure.client.ProductClient;
 import com.supersonic.limitedstore.domain.order.presentation.dto.req.OrderRequestDto;
+import com.supersonic.limitedstore.domain.order.repository.OrderEventLogRepository;
 import com.supersonic.limitedstore.domain.order.repository.OrderRepository;
 import com.supersonic.limitedstore.domain.order.service.OrderService;
 import com.supersonic.limitedstore.domain.product.entity.Product;
@@ -33,6 +34,9 @@ public class StockConcurrencyTest {
     private OrderRepository orderRepository;
 
     @Autowired
+    private OrderEventLogRepository  orderEventLogRepository;
+
+    @Autowired
     private ProductRepository productRepository;
 
     @MockBean
@@ -40,12 +44,13 @@ public class StockConcurrencyTest {
 
     @BeforeEach
     void setUp() {
+        orderEventLogRepository.deleteAll();
         orderRepository.deleteAll();
         productRepository.deleteAll();
     }
 
     @Test
-    void 동시에_100명_주문시_재고_음수() throws InterruptedException {
+    void 낙관적락_적용후_재고_정합성_보장() throws InterruptedException {
         Product product = Product.builder()
             .name("테스트상품")
             .description("테스트")


### PR DESCRIPTION
## 구현 내용

### 1) 낙관적 락 적용 (@Version)
- Product 엔티티에 @Version 필드 추가
- JPA가 UPDATE 쿼리에 version 조건을 자동으로 추가하여 동시 수정 충돌 감지
- 충돌 발생 시 OptimisticLockException 발생 → 트랜잭션 롤백

### 2) 동시성 문제 재현 및 해결 검증
- 낙관적 락 미적용 시: 재고 10개 상품에 100개 동시 요청 → 최종 재고 4 (정합성 깨짐)
- 낙관적 락 적용 후: 동일 조건 → 최종 재고 0 (정합성 보장)

---

## 기술적 고려 사항
- 낙관적 락은 충돌이 적은 환경에서 유리 (충돌 시 재시도 비용 발생)
- 충돌이 잦은 환경에서는 비관적 락(@Lock) 적용이 더 적합
- 현재 단일 서버 환경 기준으로 낙관적 락으로 정합성 보장 확인
- 분산 환경에서는 Redis 분산 락 등 추가 전략 고려 필요

---

## 관련 이슈
- closes #37 