### PR TITLE
Feature: CORS 옵션 추가

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/common/config/SecurityConfig.java
+++ b/src/main/java/com/supersonic/limitedstore/common/config/SecurityConfig.java
@@ -19,6 +19,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthFilter jwtAuthFilter) throws Exception {
         http
+            .cors(cors -> cors.configurationSource(request -> {
+                var config = new org.springframework.web.cors.CorsConfiguration();
+                config.addAllowedOrigin("*");
+                config.addAllowedMethod("*");
+                config.addAllowedHeader("*");
+                return config;
+            }))
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(


### PR DESCRIPTION
## 구현 내용
### 1) CORS 설정 추가
- SecurityConfig에 CORS 설정 추가
  - 모든 Origin 허용
  - 모든 HTTP 메서드 허용 (GET, POST, PUT, DELETE, PATCH)
  - 모든 Header 허용
- 프론트엔드에서 백엔드 API 호출 시 발생하던 CORS 오류 해결

---
## 기술적 고려 사항
- Spring Security filterChain 내부에 CORS 설정을 추가하여 Security 필터와 함께 동작하도록 구성
- 현재는 개발 편의를 위해 모든 Origin을 허용하도록 설정
- 운영 환경에서는 허용할 Origin을 특정 도메인으로 제한하는 것을 고려해야 함

---
## 관련 이슈
- closes #39 