### PR TITLE
feat: 로그인 및 상품 목록 프론트엔드 화면 추가

### DIFF
--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+    <head>
+         <title>Limited Store</title>
+         <style>
+         body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #f0f0f0;
+        }
+        .login-box {
+            background-color: white;
+            padding: 40px;
+            border-radius: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        input {
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        button {
+            padding: 10px;
+            background-color: #4caf50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        </style>
+    </head>
+    <body>
+        <div class="login-box">
+            <h2>Limited Store 로그인</h2>
+            <input type="text" id="email" placeholder="이메일">
+            <input type="password" id="password" placeholder="비밀번호">
+            <button onclick="login()">로그인</button>
+        </div>
+        <script>
+            function login() {
+                const email = document.getElementById("email").value;
+                const password = document.getElementById("password").value;
+                
+                fetch("http://localhost:8080/v1/users/login", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json"
+                    },
+                    body: JSON.stringify({
+                        email: email,
+                        password: password
+                    })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    localStorage.setItem("token", data.data.accessToken);
+                    alert("로그인 성공!");
+                    window.location.href="products.html";
+                   
+                })
+                .catch(error => {
+                    console.log("에러:", error);
+                });
+               
+                }
+            
+        </script>
+    </body>
+   
+</html>

--- a/src/main/resources/static/products.html
+++ b/src/main/resources/static/products.html
@@ -1,0 +1,63 @@
+<<!DOCTYPE html>
+<html>
+<head>
+    <title>상품 목록</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+        }
+        h1 {
+            color: #333;
+        }
+        .product-list {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .product-item {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+        }
+    </style>
+</head>
+<body>
+    <h1>상품 목록</h1>
+    <div class="product-list" id="product-list">
+        로딩 중...
+    </div>
+
+    <script>
+        const token = localStorage.getItem("token");
+
+        fetch("http://localhost:8080/v1/products", {
+            method: "GET",
+            headers: {
+                "Authorization": "Bearer " + token
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            const products = data.data;
+            const productList = document.getElementById("product-list");
+
+            productList.innerHTML = "";
+
+            products.forEach(product => {
+                productList.innerHTML += `
+                <div class="product-item">
+                    <h3>${product.name}</h3>
+                    <p>가격: ${product.price}원</p>
+                    <p>재고: ${product.stock}개</p>
+                </div>
+                `;
+            });
+        })
+        .catch(error => {
+            console.log("에러:", error);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 구현 내용
### 1) 로그인 화면 구현
- 이메일/비밀번호 입력 폼 구성
- 로그인 버튼 클릭 시 백엔드 로그인 API 호출
- 로그인 성공 시 accessToken을 localStorage에 저장
- 로그인 성공 후 상품 목록 페이지로 이동

### 2) 상품 목록 화면 구현
- localStorage에서 토큰 꺼내서 Authorization 헤더에 담아 API 호출
- 상품 목록 API 응답 데이터를 화면에 동적으로 출력
- 상품명, 가격, 재고 정보 표시

---
## 기술적 고려 사항
- fetch API를 사용하여 백엔드 REST API 연동
- JWT 토큰을 localStorage에 저장하여 페이지 이동 후에도 인증 유지
- forEach를 통해 상품 목록을 동적으로 렌더링
- 정적 파일은 Spring Boot static 폴더에 위치시켜 프로젝트에 통합

---
## 관련 이슈
- closes #41 