### PR TITLE
feat: 상품 목록 주문 기능 추가

### DIFF
--- a/src/main/java/com/supersonic/limitedstore/common/config/SecurityConfig.java
+++ b/src/main/java/com/supersonic/limitedstore/common/config/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
                     "/swagger-resources/**",
-                    "/webjars/**"
+                    "/webjars/**",
+                    "/*.html",
+                    "/static/**"
 
                 ).permitAll()
                 .anyRequest().authenticated()

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
          <title>Limited Store</title>
          <style>
          body {

--- a/src/main/resources/static/products.html
+++ b/src/main/resources/static/products.html
@@ -1,6 +1,7 @@
-<<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>상품 목록</title>
     <style>
         body {
@@ -30,34 +31,58 @@
     </div>
 
     <script>
-        const token = localStorage.getItem("token");
+       const token = localStorage.getItem("token");
 
-        fetch("http://localhost:8080/v1/products", {
-            method: "GET",
-            headers: {
-                "Authorization": "Bearer " + token
-            }
+fetch("http://localhost:8080/v1/products", {
+    method: "GET",
+    headers: {
+        "Authorization": "Bearer " + token
+    }
+})
+.then(response => response.json())
+.then(data => {
+    const products = data.data;
+    const productList = document.getElementById("product-list");
+
+    productList.innerHTML = "";
+
+    products.forEach(product => {
+        const item = document.createElement("div");
+        item.className = "product-item";
+        item.innerHTML = 
+            "<h3>" + product.name + "</h3>" +
+            "<p>가격: " + product.price + "원</p>" +
+            "<p>재고: " + product.stock + "개</p>" +
+            "<button onclick=\"order('" + product.id + "')\">주문하기</button>";
+        productList.appendChild(item);
+    });
+})
+.catch(error => {
+    console.log("에러:", error);
+});
+
+function order(productId) {
+    const token = localStorage.getItem("token");
+
+    fetch("http://localhost:8080/v1/orders", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + token
+        },
+        body: JSON.stringify({
+            productId: productId
         })
-        .then(response => response.json())
-        .then(data => {
-            const products = data.data;
-            const productList = document.getElementById("product-list");
-
-            productList.innerHTML = "";
-
-            products.forEach(product => {
-                productList.innerHTML += `
-                <div class="product-item">
-                    <h3>${product.name}</h3>
-                    <p>가격: ${product.price}원</p>
-                    <p>재고: ${product.stock}개</p>
-                </div>
-                `;
-            });
-        })
-        .catch(error => {
-            console.log("에러:", error);
-        });
+    })
+    .then(response => response.json())
+    .then(data => {
+        console.log("주문 응답:", data);
+        alert("주문 성공!");
+    })
+    .catch(error => {
+        console.log("에러:", error);
+    });
+}
     </script>
 </body>
 </html>


### PR DESCRIPTION
## 구현 내용
### 1) 주문하기 기능 추가
- 상품 목록 각 아이템에 주문하기 버튼 추가
- 주문하기 버튼 클릭 시 주문 API 호출
- localStorage에서 토큰 꺼내서 Authorization 헤더에 담아 요청
- 주문 성공 시 팝업 알림 표시

---
## 기술적 고려 사항
- fetch API로 POST 요청 시 Content-Type과 Authorization 헤더 설정
- 상품 id를 주문 API 요청 바디에 담아서 전송
- 현재 product-service 미구동으로 주문 API 500 에러 발생
- 추후 ProductClient 수정 브랜치에서 해결 예정

---
## 관련 이슈
- closes: #43 